### PR TITLE
Remove reference to ansible-container

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,10 +115,6 @@
                 href="ansible/latest/community/index.html">
                 Community Information and Contributing
             </a>
-            <a class="DocSiteLink DocSiteLink--core DocSiteLink--noPdf"
-                href="ansible-container/index.html">
-                Ansible-Container
-            </a>
 
             <hr class="DocSiteProduct-linkSpacer">
 


### PR DESCRIPTION
The project is no longer supported by any Ansible / Red Hat engineers, so it's no longer appropriate to have the docs linked on the front page of the docs site.