### PR TITLE
updates versions, proposes other changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,17 +7,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
-    
+
     <title>Ansible Documentation</title>
     <meta name="description" content="Ansible Documentation">
     <meta name="author" content="Ansible, Inc.">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,400i,700" rel="stylesheet">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" /> 
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" />
     <!-- <link rel='stylesheet' href='style.css' /> -->
-    <link rel="stylesheet" href="styles/style.css"> 
+    <link rel="stylesheet" href="styles/style.css">
 
 
-    
+
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -28,7 +28,7 @@
       ga('send', 'pageview');
 
     </script>
-    
+
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" crossorigin="anonymous"></script>
     <script src="//www.redhat.com/dtm.js"></script>
@@ -36,7 +36,7 @@
 </head>
 
 <style>
-    
+
 
 
 
@@ -52,9 +52,9 @@
             <span class="icon-bar center"></span>
             <span class="icon-bar bottom"></span>
         </button>
-        
-        
-          
+
+
+
         <div class="collapse navbar-collapse" id="main-menu">
             <div class="container">
                 <ul class="navbar-nav justify-content-end">
@@ -125,16 +125,16 @@
             </div>
         </div>
     </section>
-    
+
     <section id="project" class="btn-grid pt-0 pb-4">
-        
+
         <div class="container">
             <div class="row">
                 <div class="col">
                     <h1>Ansible Project</h1>
                 </div>
             </div>
-            
+
             <div class="row">
                 <div class="col-md-4">
                     <a href="http://docs.ansible.com/ansible/index.html" class="btn btn-project">Ansible Documentation</a>
@@ -167,44 +167,44 @@
                     <a href="http://docs.ansible.com/ansible/community.html" class="btn btn-project">Community Info</a>
                 </div>
                 <div class="col-md-4">
-                    <a data-toggle="collapse" href="#project-prev"  class="btn btn-project btn-more collapsed">Previous Versions</a>
+                    <a data-toggle="collapse" href="#project-prev"  class="btn btn-project btn-more collapsed">Documentation for Other Versions</a>
                 </div>
             </div>
         </div>
-        
+
     </section>
-    
+
     <section id="project-prev" class="py-0 collapse">
         <div class="container">
             <div class="row justify-content-center">
                 <div class="col-md-4">
                     <ul class="nav">
                         <li class="nav-item">
-                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.4/index.html">Ansible Project version 2.4</a>
+                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.4/index.html">Ansible Project, version 2.4</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.3/index.html">Ansible Project version 2.3</a>
+                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.5/index.html">Ansible Project, version 2.5</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="http://docs.ansible.com/ansible/devel/index.html">Ansible Project Development</a>
+                            <a class="nav-link" href="http://docs.ansible.com/ansible/devel/index.html">Ansible Project, devel branch</a>
                         </li>
                     </ul>
                 </div>
             </div>
         </div>
     </section>
-    
-    
-    
+
+
+
     <!--section id="engine" class="btn-grid pb-0">
-        
+
         <div class="container">
             <div class="row">
                 <div class="col">
                     <h1>Red Hat Ansible Engine</h1>
                 </div>
             </div>
-            
+
             <div class="row">
                 <div class="col-md-4">
                     <a href="#" class="btn btn-engine">Ansible Documentation</a>
@@ -217,20 +217,20 @@
                 </div>
             </div>
         </div>
-        
+
     </section-->
-    
-    
-    
+
+
+
     <section id="tower" class="btn-grid pt-0 pb-4">
-        
+
         <div class="container">
             <div class="row">
                 <div class="col">
                     <h1>Red Hat Ansible Tower</h1>
                 </div>
             </div>
-            
+
             <div class="row">
                 <div class="col-md-4">
                     <a href="https://www.ansible.com/tower-demo" class="btn btn-tower">Overview Video</a>
@@ -268,7 +268,7 @@
             </div>
         </div>
     </section>
-    
+
     <section id="tower-prev" class="py-0 collapse">
         <div class="container">
             <div class="row">
@@ -319,13 +319,13 @@
 						</li>
                         <li class="nav-item">
 							<a class="nav-link" href="http://docs.ansible.com/ansible-tower/3.1.0/html/">Tower 3.1.0</a>
-						</li> 
+						</li>
                         <li class="nav-item">
 							<a class="nav-link" href="http://docs.ansible.com/ansible-tower/3.0.4/html/">Tower 3.0.4</a>
 						</li>
                         <li class="nav-item">
 							<a class="nav-link" href="http://docs.ansible.com/ansible-tower/3.0.3/html/">Tower 3.0.3</a>
-						</li> 
+						</li>
                         <li class="nav-item">
 							<a class="nav-link" href="http://docs.ansible.com/ansible-tower/3.0.2/html/">Tower 3.0.2</a>
 						</li>
@@ -374,13 +374,13 @@
                 </div>
             </div>
         </div>
-        
+
     </section>
-    
+
     <section id="tower-translated" class="py-0 collapse">
         <div class="container">
             <div class="row justify-content-center">
-                <div class="col-md-3 text-center">    
+                <div class="col-md-3 text-center">
                     <h4>Tower 3.2.2</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -409,9 +409,9 @@
                            </li>
                        </ul>
                    </div>
-                   <div class="col-md-3 text-center">    
+                   <div class="col-md-3 text-center">
                     <h4>Tower 3.1.4</h4>
-                       <ul class="nav d-block">    
+                       <ul class="nav d-block">
                         <li class="nav-item">
                             <a class="nav-link" href="http://docs.ansible.com/ansible-tower/3.1.4/html_ja/quickstart/">Japanese: Ansible Tower Quick Start Guide v3.1.4</a>
                         </li>
@@ -444,14 +444,14 @@
 
 
        <section id="network" class="btn-grid pt-0 pb-4">
-        
+
         <div class="container">
             <div class="row">
                 <div class="col">
                     <h1>Ansible Network</h1>
                 </div>
             </div>
-            
+
             <div class="row">
                 <div class="col-md-4">
                     <a href="https://docs.ansible.com/ansible/latest/network/" class="btn btn-project">Network Documentation</a>
@@ -468,14 +468,14 @@
 </div></div></section>
 
        <section id="galaxy" class="btn-grid pt-0 pb-4">
-        
+
         <div class="container">
             <div class="row">
                 <div class="col">
                     <h1>Ansible Galaxy</h1>
                 </div>
             </div>
-            
+
             <div class="row">
                  <div class="col-md-4">
                     <a href="https://galaxy.ansible.com/docs/" class="btn btn-engine">Galaxy Documentation</a>
@@ -497,23 +497,23 @@
 
 
 
-    
+
     <section id="ansible-footer" class="pb-0">
         <iframe src="https://www.ansible.com/docs-footer" scrolling="no"></iframe>
     </section>
-    
+
     <script>
         $(document).ready(function(){
             $('iframe').iFrameResize( [{log:true}] );
-            
+
             // make tower collapsibles work like an accordian
             $("section[id*='tower']").on('show.bs.collapse', function () {
                 var id = $(this).attr("id");
                 console.log(id);
-                
+
                 $("section[id*='tower']").not(id).removeClass("show");
                 $("section[id*='tower'] a[href!='"+id+"']").addClass("collapsed");
-                
+
             });
         });
     </script>


### PR DESCRIPTION
This PR updates the list of old documentation versions and changes the label on that box. We're not supporting Ansible 2.3 any more, so we shouldn't link to those docs from the landing page. Since we'll be releasing Ansible 2.7 soon, this change is a dry-run for that release as well.

And, apparently, it made a bunch of whitespace edits. 

The substantive changes are in lines 170 and 183-89.
