### PR TITLE
updates other versions for 2.7 release

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,10 +180,10 @@
                 <div class="col-md-4">
                     <ul class="nav">
                         <li class="nav-item">
-                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.4/index.html">Ansible Project, version 2.4</a>
+                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.5/index.html">Ansible Project, version 2.5</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.5/index.html">Ansible Project, version 2.5</a>
+                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.6/index.html">Ansible Project, version 2.6</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="http://docs.ansible.com/ansible/devel/index.html">Ansible Project, devel branch</a>


### PR DESCRIPTION
This updates the list of alternative versions of the documentation available on docs.ansible.com. Note that we have not removed the 2.4 docs, but we no longer list them in the drop-down on the home page, since 2.4 is no longer supported now that 2.7 has been released.