### PR TITLE
[Doc-Release-2.8] Update ansible doc versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,10 +183,10 @@
                 <div class="col-md-4">
                     <ul class="nav">
                         <li class="nav-item">
-                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.5/index.html">Ansible Project, version 2.5</a>
+                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.6/index.html">Ansible Project, version 2.6</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.6/index.html">Ansible Project, version 2.6</a>
+                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.7/index.html">Ansible Project, version 2.7</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="http://docs.ansible.com/ansible/devel/index.html">Ansible Project, devel branch</a>


### PR DESCRIPTION
Signed-off-by: Sandra McCann <samccann@redhat.com>

Change the listed Ansible engine documentation versions to coincide with the 2.8 release (aka 2,6, 2.7, and devel)