### PR TITLE
redirects tech preview page

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -28,6 +28,10 @@ RedirectMatch permanent "^/ansible/(devel|latest)/modules.html" "/ansible/$1/use
 RedirectMatch permanent "^/ansible/community.html" "/ansible/latest/community.html"
 RedirectMatch permanent "^/ansible/(devel|latest)/community.html" "/ansible/$1/community/index.html"
 
+# Redirects for moved collections page
+
+RedirectMatch permanent "^/ansible/devel/dev_guide/collections_tech_preview.html" "/ansible/devel/user_guide/collections_using.html"
+
 # Redirects for refactored Ansible core docs
 
 # CLI


### PR DESCRIPTION
We split the content from
https://docs.ansible.com/ansible/devel/dev_guide/collections_tech_preview.html 

into

user guide https://docs.ansible.com/ansible/devel/user_guide/collections_using.html
dev guide https://docs.ansible.com/ansible/devel/dev_guide/developing_collections.html#developing-collections

but searches still get the old page. Redirecting.
