### PR TITLE
Updates Engine 'other versions' list for 2.9

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,10 +183,10 @@
                 <div class="col-md-4">
                     <ul class="nav">
                         <li class="nav-item">
-                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.6/index.html">Ansible Project, version 2.6</a>
+                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.7/index.html">Ansible Project, version 2.7</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.7/index.html">Ansible Project, version 2.7</a>
+                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.8/index.html">Ansible Project, version 2.8</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="http://docs.ansible.com/ansible/devel/index.html">Ansible Project, devel branch</a>
@@ -443,7 +443,7 @@
     <section id="tower-translated" class="py-0 collapse">
         <div class="container">
             <div class="row justify-content-center">
-                 <div class="col-md-3 text-center">    
+                 <div class="col-md-3 text-center">
                     <h4>Tower 3.5.2</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -472,7 +472,7 @@
                            </li>
                        </ul>
                    </div>
-                    <div class="col-md-3 text-center">    
+                    <div class="col-md-3 text-center">
                     <h4>Tower 3.5.1</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -501,7 +501,7 @@
                            </li>
                        </ul>
                    </div>
-                 <div class="col-md-3 text-center">    
+                 <div class="col-md-3 text-center">
                     <h4>Tower 3.4.3</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -530,7 +530,7 @@
                            </li>
                        </ul>
                    </div>
-                 <div class="col-md-3 text-center">    
+                 <div class="col-md-3 text-center">
                     <h4>Tower 3.4.2</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -559,7 +559,7 @@
                            </li>
                        </ul>
                    </div>
-                <div class="col-md-3 text-center">    
+                <div class="col-md-3 text-center">
                     <h4>Tower 3.3.2</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -588,7 +588,7 @@
                            </li>
                        </ul>
                    </div>
-                <div class="col-md-3 text-center">    
+                <div class="col-md-3 text-center">
                     <h4>Tower 3.2.4</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -733,14 +733,14 @@
 
 
        <section id="lint" class="btn-grid pt-0 pb-4">
- 
+
          <div class="container">
              <div class="row">
                  <div class="col">
                      <h1>Ansible Lint</h1>
                  </div>
              </div>
- 
+
              <div class="row">
                   <div class="col-md-4">
                      <a href="https://docs.ansible.com/ansible-lint/" class="btn btn-project">Lint Documentation</a>


### PR DESCRIPTION
Now that Ansible 2.9 has been released, the docsite landing page should offer `devel`, `2.8`, and `2.7` as available other versions.