### PR TITLE
add redirect for galaxy appendix move

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -159,7 +159,7 @@ RedirectMatch permanent "^/ansible/(devel|latest)/porting_guides.html" "/ansible
 RedirectMatch permanent "^/ansible/(devel|latest)/common_return_values.html" "/ansible/$1/reference_appendices/common_return_values.html"
 RedirectMatch permanent "^/ansible/(devel|latest)/config.html" "/ansible/$1/reference_appendices/config.html"
 RedirectMatch permanent "^/ansible/(devel|latest)/faq.html" "/ansible/$1/reference_appendices/faq.html"
-RedirectMatch permanent "^/ansible/(devel|latest)/glossary.html" "/ansible/$1/galaxy/user_guide.html"
+RedirectMatch permanent "^/ansible/(devel|latest)/galaxy.html" "/ansible/$1/galaxy/user_guide.html"
 RedirectMatch permanent "^/ansible/(devel|latest)/reference_appendices/galaxy.html" "/ansible/$1/galaxy/user_guide.html"
 RedirectMatch permanent "^/ansible/(devel|latest)/glossary.html" "/ansible/$1/reference_appendices/glossary.html"
 RedirectMatch permanent "^/ansible/(devel|latest)/guide_aci.html" "/ansible/$1/reference_appendices/guide_aci.html"


### PR DESCRIPTION
Galaxy appendix has moved to its own section. Add a redirect and update the old old galaxy redirect to also point at  this new location.