### PR TITLE
update galaxy links to docs.ansible.com/ansible-galaxy/

### DIFF
--- a/index.html
+++ b/index.html
@@ -721,19 +721,16 @@
 
             <div class="row">
                  <div class="col-md-4">
-                    <a href="https://galaxy.ansible.com/docs/" class="btn btn-engine">Galaxy Documentation</a>
+                    <a href="https://docs.ansible.com/ansible-galaxy/latest/" class="btn btn-engine">Galaxy Documentation</a>
                 </div>
                 <div class="col-md-4">
-                    <a href="https://galaxy.ansible.com/docs/using/index.html" class="btn btn-engine">Using Content</a>
+                    <a href="https://docs.ansible.com/ansible-galaxy/latest/using/index.html" class="btn btn-engine">Using Content</a>
                 </div>
                 <div class="col-md-4">
-                    <a href="https://galaxy.ansible.com/docs/contributing/index.html" class="btn btn-engine">Contributing Content</a>
+                    <a href="https://docs.ansible.com/ansible-galaxy/latest/contributing/index.html" class="btn btn-engine">Contributing Content</a>
                 </div>
                 <div class="col-md-4">
-                    <a href="https://galaxy.ansible.com/docs/mazer/index.html" class="btn btn-engine">Mazer</a>
-                </div>
-                <div class="col-md-4">
-                    <a href="https://galaxy.ansible.com/docs/developers/index.html" class="btn btn-engine">Developer's Guide</a>
+                    <a href="https://docs.ansible.com/ansible-galaxy/latest/developers/index.html" class="btn btn-engine">Developer's Guide</a>
                 </div>
             </div></div></section>
 


### PR DESCRIPTION
Galaxy docs moved to docs.ansible.com/ansible-galaxy/.  Update index page to show this and remove mazer.