### PR TITLE
removes redirect to /modules to allow collections-based module docs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,7 +15,10 @@ RedirectMatch permanent "^/ansible/(?!latest|devel|\d\.+)(.+)?.html" "/ansible/l
 RedirectMatch permanent "^/ansible/devel/module_docs/?(.+)?" "/ansible/devel/modules/$1"
 RedirectMatch permanent "^/ansible/latest/module_docs/?(.+)?" "/ansible/latest/modules/$1"
 
-RedirectMatch permanent "^/ansible/(devel|latest)/(?!modules)(.+_module).html" "/ansible/$1/modules/$2.html"
+# with collections, modules go in /collections/namespace/collection_name/module_name with no /modules
+# changing this so it will not hit /devel
+# can we get rid of this redirect?
+RedirectMatch permanent "^/ansible/latest/(?!modules)(.+_module).html" "/ansible/$1/modules/$2.html"
 
 RedirectMatch permanent "^/ansible/modules_by_category.html" "/ansible/latest/modules_by_category.html"
 RedirectMatch permanent "^/ansible/(devel|latest)/modules_by_category.html" "/ansible/$1/modules/modules_by_category.html"


### PR DESCRIPTION
In the collections ecosystem, module documentation lives at URLs like:

http://docs.testing.ansible.com/ansible/devel/collections/amazon/aws/aws_az_info_module.html

but those URLs keep redirecting with an added /modules/:

http://docs.testing.ansible.com/ansible/devel/modules/collections/amazon/aws/aws_az_info_module.html

The old pattern last existed in Ansible 2.4: https://docs.ansible.com/ansible/2.4/command_module.html. It has been two and a half years since Ansible 2.5 was released. As a first step, I've removed the redirect for /devel. Can we move on?