### PR TITLE
removed mazer and ansible-lint

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@ if (location.host == "docs.testing.ansible.com") {
                         <a class="nav-link" href="#galaxy">Ansible Galaxy Docs</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="#lint">Ansible Lint Docs</a>
+                        <a class="nav-link" href="https://ansible-lint.readthedocs.io/en/latest/">Ansible Lint Docs</a>
                     </li>
                      <!-- <li class="nav-item">
                         <a class="nav-link" href="#engine">Ansible Use Case Docs</a>
@@ -165,12 +165,9 @@ if (location.host == "docs.testing.ansible.com") {
                 <div class="col-md-4">
                     <a href="http://docs.ansible.com/ansible/intro_inventory.html" class="btn btn-project">Inventory</a>
                 </div>
-                <div class="col-md-4">
+              <!--  <div class="col-md-4">
                     <a href="http://docs.ansible.com/ansible/modules_by_category.html" class="btn btn-project">Module Index</a>
-                </div>
-                <div class="col-md-4">
-                    <a href="http://docs.ansible.com/ansible/list_of_network_modules.html" class="btn btn-project">Network Modules</a>
-                </div>
+                </div> -->
                 <div class="col-md-4">
                     <a href="http://docs.ansible.com/ansible/latest/dev_guide/index.html" class="btn btn-project">Developer Guide</a>
                 </div>
@@ -180,9 +177,26 @@ if (location.host == "docs.testing.ansible.com") {
                 <div class="col-md-4">
                     <a data-toggle="collapse" href="#project-prev"  class="btn btn-project btn-more collapsed">Documentation for Other Versions</a>
                 </div>
+                <div class="col-md-4">
+                    <a data-toggle="collapse" href="#project-translated-ja"  class="btn btn-project btn-more collapsed">>日本語ドキュメント - Japanese Translations</a>
+                </div>
             </div>
         </div>
 
+    </section>
+
+    <section id="project-translated-ja" class="py-0 collapse">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-md-4">
+                    <ul class="nav">
+                        <li class="nav-item">
+                            <a class="nav-link" href="https://docs.ansible.com/ansible/2.9_ja/index.html">Ansible ドキュメント 2.9</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
     </section>
 
     <section id="project-prev" class="py-0 collapse">
@@ -191,10 +205,10 @@ if (location.host == "docs.testing.ansible.com") {
                 <div class="col-md-4">
                     <ul class="nav">
                         <li class="nav-item">
-                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.7/index.html">Ansible Project, version 2.7</a>
+                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.8/index.html">Ansible Project, version 2.8</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.8/index.html">Ansible Project, version 2.8</a>
+                            <a class="nav-link" href="http://docs.ansible.com/ansible/2.9/index.html">Ansible Project, version 2.9</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="http://docs.ansible.com/ansible/devel/index.html">Ansible Project, devel branch</a>
@@ -204,8 +218,6 @@ if (location.host == "docs.testing.ansible.com") {
             </div>
         </div>
     </section>
-
-
 
     <!--section id="engine" class="btn-grid pb-0">
 
@@ -338,7 +350,7 @@ if (location.host == "docs.testing.ansible.com") {
                 </div>
                 <div class="col-md-3 text-center">
                     <h4>Tower 3.4.5 and Earlier (End of Maintenance Support - EOL)</h4>
-                    <ul class="nav d-block"> 
+                    <ul class="nav d-block">
                         <li class="nav-item">
                           <a class="nav-link" href="http://docs.ansible.com/ansible-tower/3.4.5/html/">Tower 3.4.5</a>
                         </li>
@@ -356,7 +368,7 @@ if (location.host == "docs.testing.ansible.com") {
                         </li>
                         <li class="nav-item">
                           <a class="nav-link" href="http://docs.ansible.com/ansible-tower/3.4.0/html/">Tower 3.4.0</a>
-                        </li>                       
+                        </li>
                         <li class="nav-item">
                           <a class="nav-link" href="http://docs.ansible.com/ansible-tower/3.3.7/html/">Tower 3.3.7</a>
                         </li>
@@ -494,14 +506,14 @@ if (location.host == "docs.testing.ansible.com") {
                 </div>
             </div>
         </div>
-        
+
     </section>
 
     <section id="tower-translated-ja" class="py-0 collapse">
         <div class="container">
             <div class="row justify-content-center">
 
-            <div class="col-md-3 text-center">    
+            <div class="col-md-3 text-center">
                     <h4>Tower 3.7.1</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -531,7 +543,7 @@ if (location.host == "docs.testing.ansible.com") {
                        </ul>
                    </div>
 
-            <div class="col-md-3 text-center">    
+            <div class="col-md-3 text-center">
                     <h4>Tower 3.7.0</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -561,7 +573,7 @@ if (location.host == "docs.testing.ansible.com") {
                        </ul>
                    </div>
 
-        <div class="col-md-3 text-center">    
+        <div class="col-md-3 text-center">
                     <h4>Tower 3.6.4</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -591,7 +603,7 @@ if (location.host == "docs.testing.ansible.com") {
                        </ul>
                    </div>
 
-                <div class="col-md-3 text-center">    
+                <div class="col-md-3 text-center">
                     <h4>Tower 3.6.3</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -621,7 +633,7 @@ if (location.host == "docs.testing.ansible.com") {
                        </ul>
                    </div>
 
-                <div class="col-md-3 text-center">    
+                <div class="col-md-3 text-center">
                     <h4>Tower 3.6.2</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -651,7 +663,7 @@ if (location.host == "docs.testing.ansible.com") {
                        </ul>
                    </div>
 
-                <div class="col-md-3 text-center">    
+                <div class="col-md-3 text-center">
                     <h4>Tower 3.6.0</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -922,7 +934,7 @@ if (location.host == "docs.testing.ansible.com") {
         <div class="container">
             <div class="row justify-content-center">
 
-                <div class="col-md-3 text-center">    
+                <div class="col-md-3 text-center">
                     <h4>Tower 3.7.1</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -952,7 +964,7 @@ if (location.host == "docs.testing.ansible.com") {
                        </ul>
                    </div>
 
-               <div class="col-md-3 text-center">    
+               <div class="col-md-3 text-center">
                     <h4>Tower 3.7.0</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -982,7 +994,7 @@ if (location.host == "docs.testing.ansible.com") {
                        </ul>
                    </div>
 
-                <div class="col-md-3 text-center">    
+                <div class="col-md-3 text-center">
                     <h4>Tower 3.6.4</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -1013,7 +1025,7 @@ if (location.host == "docs.testing.ansible.com") {
                    </div>
 
 
-                <div class="col-md-3 text-center">    
+                <div class="col-md-3 text-center">
                     <h4>Tower 3.6.3</h4>
                     <ul class="nav d-block">
                         <li class="nav-item">
@@ -1066,7 +1078,7 @@ if (location.host == "docs.testing.ansible.com") {
                     <a href="http://docs.ansible.com/ansible/intro_installation.html" class="btn btn-project">Installation</a>
                 </div>
                 <div class="col-md-4">
-                    <a href="http://docs.ansible.com/ansible/intro_getting_started.html" class="btn btn-project">Getting Started</a>
+                    <a href="https://docs.ansible.com/ansible/latest/network/getting_started/index.html" class="btn btn-project">Getting Started</a>
                 </div>
 </div></div></section>
 
@@ -1090,15 +1102,12 @@ if (location.host == "docs.testing.ansible.com") {
                     <a href="https://galaxy.ansible.com/docs/contributing/index.html" class="btn btn-engine">Contributing Content</a>
                 </div>
                 <div class="col-md-4">
-                    <a href="https://galaxy.ansible.com/docs/mazer/index.html" class="btn btn-engine">Mazer</a>
-                </div>
-                <div class="col-md-4">
                     <a href="https://galaxy.ansible.com/docs/developers/index.html" class="btn btn-engine">Developer's Guide</a>
                 </div>
             </div></div></section>
 
 
-       <section id="lint" class="btn-grid pt-0 pb-4">
+<!--       <section id="lint" class="btn-grid pt-0 pb-4">
 
          <div class="container">
              <div class="row">
@@ -1123,7 +1132,7 @@ if (location.host == "docs.testing.ansible.com") {
                  <div class="col-md-4">
                      <a href="https://docs.ansible.com/ansible-lint/rules/rules.html" class="btn btn-project">Rules</a>
                  </div>
-             </div></div></section>
+             </div></div></section> -->
 
 
     <section id="ansible-footer" class="pb-0">


### PR DESCRIPTION
Partial fix for #24 -

- Removes mazer. 
- Replaces ansible-lint top link to go to readthedocs.
- adds dropdown for Ansible japanese translation
- updates prior versions to 2.8,2.9.
- removes 'module index' as that won't work in the 2.10 world.