### PR TITLE
Lint docs redirect

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -197,4 +197,4 @@ RedirectMatch permanent "^/ansible/(devel|latest)/vmware/vmware_?(.+)?" "/ansibl
 RedirectMatch permanent "^\/ansible-tower\/((2\.\d\.\d)|3\.[0-3]\.\d)\/html(_\w+)?\/.*updates_support\.html$" "/ansible-tower/latest/html$3/installandreference/updates_support.html"
 
 # Redirect all ansible-lint pages to ReadTheDocs
-RedirectMatch permanent "^/ansible-lint/?(.+)?" "https://ansible-lint.readthedocs.io"
+RedirectMatch permanent "^/ansible-lint/*" "https://ansible-lint.readthedocs.io"


### PR DESCRIPTION
Redirects all pages in the documentation for ansible-lint to ReadTheDocs.