### PR TITLE
fix the redirect regex for modules

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -18,7 +18,7 @@ RedirectMatch permanent "^/ansible/latest/module_docs/?(.+)?" "/ansible/latest/m
 # with collections, modules go in /collections/namespace/collection_name/module_name with no /modules
 # changing this so it will not hit /devel
 # can we get rid of this redirect?
-RedirectMatch permanent "^/ansible/latest/(?!modules)(.+_module).html" "/ansible/$1/modules/$2.html"
+RedirectMatch permanent "^/ansible/latest/(?!modules)(.+_module).html" "/ansible/latest/modules/$1.html"
 
 RedirectMatch permanent "^/ansible/modules_by_category.html" "/ansible/latest/modules_by_category.html"
 RedirectMatch permanent "^/ansible/(devel|latest)/modules_by_category.html" "/ansible/$1/modules/modules_by_category.html"


### PR DESCRIPTION
This will fix the broken Tower links with redirection. Longer-term those links should point to the current location of the module docs in question.