### PR TITLE
reinstates config turning multiviews off, supports plugin redirects

### DIFF
--- a/ansible/.htaccess
+++ b/ansible/.htaccess
@@ -1,1 +1,2 @@
+Options -MultiViews
 ErrorDocument 404 /ansible/latest/404.html


### PR DESCRIPTION
Now that the apache config has been updated on the docs.ansible.com server, it will support the `- MultiViews` config. This setting allows redirects to work for non-module plugin docs across the pre-collections/post-collections divide.