### PR TITLE
update sitemap for 2.10

### DIFF
--- a/ansible-core-sitemap.xml
+++ b/ansible-core-sitemap.xml
@@ -4,31 +4,49 @@
     <loc>https://docs.ansible.com/ansible/latest/</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/installation_guide/index.html</loc>
-  </url>
-  <url>
     <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guides.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/user_guide/index.html</loc>
   </url>
   <url>
+    <loc>https://docs.ansible.com/ansible/latest/installation_guide/index.html</loc>
+  </url>
+  <url>
     <loc>https://docs.ansible.com/ansible/latest/community/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/index.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/cloud_guides.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/network_guides.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/scenario_guides/virt_guides.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/index.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/cloud_guides.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/galaxy/user_guide.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/galaxy/dev_guide.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/dev_guide/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/reference_appendices/playbooks_keywords.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html</loc>
@@ -37,25 +55,16 @@
     <loc>https://docs.ansible.com/ansible/latest/reference_appendices/config.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/modules_by_category.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/reference_appendices/playbooks_keywords.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/reference_appendices/python_3_support.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/reference_appendices/general_precedence.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/reference_appendices/python_3_support.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/network_guides.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html</loc>
@@ -73,16 +82,22 @@
     <loc>https://docs.ansible.com/ansible/latest/reference_appendices/glossary.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/reference_appendices/module_utils.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/reference_appendices/module_utils.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/reference_appendices/tower.html</loc>
   </url>
   <url>
+    <loc>https://docs.ansible.com/ansible/latest/reference_appendices/automationhub.html</loc>
+  </url>
+  <url>
     <loc>https://docs.ansible.com/ansible/latest/roadmap/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/reference_appendices/logging.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html</loc>
@@ -91,13 +106,28 @@
     <loc>https://docs.ansible.com/ansible/latest/installation_guide/intro_configuration.html</loc>
   </url>
   <url>
+    <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_base_2.11.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_base_2.10.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.10.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.9.html</loc>
+  </url>
+  <url>
     <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.8.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.6.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.7.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.6.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.3.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html</loc>
@@ -106,67 +136,22 @@
     <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.4.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.3.html</loc>
-  </url>
-  <url>
     <loc>https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.0.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/quickstart.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_modules.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/intro_getting_started.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/command_line_tools.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/intro_adhoc.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/intro_dynamic_inventory.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/become.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/vault.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/intro_patterns.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/modules.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/plugins.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/intro_bsd.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/windows.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_best_practices.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_locally.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_modules.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_checklist.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_best_practices.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_python_3.html</loc>
@@ -178,10 +163,19 @@
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general_aci.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general_windows.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general_windows.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/platforms/aws_guidelines.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/platforms/openstack_guidelines.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/platforms/ovirt_dev_guide.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/platforms/vmware_guidelines.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_in_groups.html</loc>
@@ -194,6 +188,9 @@
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_plugins.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general_aci.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_inventory.html</loc>
@@ -211,49 +208,235 @@
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_rebasing.html</loc>
   </url>
   <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html</loc>
+  </url>
+  <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/developing_module_utilities.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/migrating_roles.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/overview_architecture.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/index.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/basic_concepts.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/index.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/network_differences.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/dev_guide/index.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/first_playbook.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_9.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/first_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_8.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/network_roles.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_7.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/intermediate_concepts.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_5.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/network_connection_options.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_6.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/network_resources.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_4.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/network_resource_modules.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_3.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/network_best_practices_2.5.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_2.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/cli_parsing.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_1.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/faq.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/network_debug_troubleshooting.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/network_working_with_command_output.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/dev_guide/developing_resource_modules_network.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/dev_guide/developing_plugins_network.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/dev_guide/documenting_modules_network.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/roadmap/ansible_base_roadmap_index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/roadmap/ansible_roadmap_index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/roadmap/old_roadmap_index.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/basic_concepts.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/quickstart.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/intro_getting_started.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/intro_adhoc.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_best_practices.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/become.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_delegation.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_blocks.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_handlers.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_environment.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_includes.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/connection_details.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/intro_dynamic_inventory.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/intro_patterns.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/command_line_tools.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_vars_facts.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/vault.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_lookups.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_prompts.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_startnstep.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_checkmode.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_debugger.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_async.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_advanced_syntax.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_strategies.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/complex_data_manipulation.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/plugin_filtering_config.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/sample_setup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/modules.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/plugins/plugins.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/intro_bsd.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/windows.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/modules_support.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_templating.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/collections_using.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_special_topics.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/guide_rolling_upgrade.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/cli/ansible.html</loc>
@@ -262,19 +445,16 @@
     <loc>https://docs.ansible.com/ansible/latest/cli/ansible-config.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/cli/ansible-console.html</loc>
-  </url>
-  <url>
     <loc>https://docs.ansible.com/ansible/latest/cli/ansible-doc.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/cli/ansible-inventory.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/cli/ansible-console.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/cli/ansible-inventory.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/cli/ansible-pull.html</loc>
@@ -283,46 +463,13 @@
     <loc>https://docs.ansible.com/ansible/latest/cli/ansible-vault.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_templating.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_blocks.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_special_topics.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_strategies.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_best_practices.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/guide_rolling_upgrade.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/modules_intro.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/modules_support.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/plugins/action.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/modules_intro.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/plugins/become.html</loc>
@@ -340,31 +487,25 @@
     <loc>https://docs.ansible.com/ansible/latest/plugins/connection.html</loc>
   </url>
   <url>
+    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup.html</loc>
+  </url>
+  <url>
     <loc>https://docs.ansible.com/ansible/latest/plugins/httpapi.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/plugins/inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/plugins/shell.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/shell.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/plugins/netconf.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/plugins/strategy.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/plugins/vars.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/plugin_filtering_config.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/user_guide/windows_setup.html</loc>
@@ -376,16 +517,19 @@
     <loc>https://docs.ansible.com/ansible/latest/user_guide/windows_usage.html</loc>
   </url>
   <url>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/windows_performance.html</loc>
+  </url>
+  <url>
     <loc>https://docs.ansible.com/ansible/latest/user_guide/windows_dsc.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/community/how_can_I_help.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/user_guide/windows_faq.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/community/code_of_conduct.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/community/how_can_I_help.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/community/reporting_bugs_and_features.html</loc>
@@ -395,6 +539,9 @@
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/community/communication.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/community/contributing_maintained_collections.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/community/development_process.html</loc>
@@ -424,7 +571,28 @@
     <loc>https://docs.ansible.com/ansible/latest/community/github_admins.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/dev_guide/developing_plugins_network.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_aci.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_meraki.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_infoblox.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_vultr.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_docker.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_kubernetes.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_vagrant.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_vmware.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_alicloud.html</loc>
@@ -457,64 +625,10 @@
     <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_scaleway.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_vultr.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/faq.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_docker.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_kubernetes.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_vagrant.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_vmware.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_infoblox.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_network_modules.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/network_maintained.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/basic_concepts.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/network_differences.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/first_playbook.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/first_inventory.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/network_roles.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/intermediate_concepts.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/getting_started/network_resources.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/faq.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/network_best_practices_2.5.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/network_debug_troubleshooting.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/network_working_with_command_output.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_index.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_ce.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_cnos.html</loc>
@@ -529,31 +643,46 @@
     <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_dellos10.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_eos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html</loc>
-  </url>
-  <url>
     <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_enos.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_netvisor.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_eos.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_eric_eccli.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_exos.html</loc>
   </url>
   <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_frr.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_icx.html</loc>
+  </url>
+  <url>
     <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_ios.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_iosxr.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_ironware.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_nxos.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_meraki.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_netvisor.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_nos.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_nxos.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_routeros.html</loc>
@@ -562,130 +691,235 @@
     <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_slxos.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_netconf_enabled.html</loc>
-  </url>
-  <url>
     <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_voss.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/faq.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_vyos.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/user_guide/platform_netconf_enabled.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_all_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_cloud_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_commands_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_crypto_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_clustering_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_database_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_files_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_identity_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_inventory_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_messaging_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/chocolatey/chocolatey/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_monitoring_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_net_tools_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/asa/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_notification_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/intersight/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_packaging_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_remote_management_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_source_control_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_storage_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_system_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_utilities_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_web_infrastructure_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cloudscale_ch/cloud/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/list_of_windows_modules.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_async.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_checkmode.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_debugger.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_delegation.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_environment.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/grafana/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_advanced_syntax.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_prompts.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/libvirt/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mysql/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_vault.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_startnstep.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/proxysql/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_lookups.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/set_fact_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/skydive/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/include_vars_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_aci.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/guide_meraki.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cyberark/conjur/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/containers/podman/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cyberark/pas/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os9/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os6/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os10/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/frr/frr/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/infinidat/infinibox/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/gluster/gluster/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/aws/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/exoscale/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openvswitch/openvswitch/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/splunk/es/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/servicenow/servicenow/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/set_fact_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_vars_module.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/action-plugin-docs.html</loc>
@@ -694,10 +928,7 @@
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/ansible-doc.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/azure-requirements.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/boilerplate.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/bin-symlinks.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/botmeta.html</loc>
@@ -718,6 +949,12 @@
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/empty-init.html</loc>
   </url>
   <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/future-import-boilerplate.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/ignores.html</loc>
+  </url>
+  <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/import.html</loc>
   </url>
   <url>
@@ -725,6 +962,9 @@
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/line-endings.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/metaclass-boilerplate.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-assert.html</loc>
@@ -739,10 +979,10 @@
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-dict-iterkeys.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-dict-itervalues.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-get-exception.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-get-exception.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-dict-itervalues.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-illegal-filenames.html</loc>
@@ -754,10 +994,16 @@
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-smart-quotes.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-tests-as-filters.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-unicode-literals.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-unicode-literals.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-unwanted-files.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/obsolete-files.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/package-data.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/pep8.html</loc>
@@ -769,6 +1015,9 @@
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/pylint.html</loc>
   </url>
   <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/release-names.html</loc>
+  </url>
+  <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/replace-urlopen.html</loc>
   </url>
   <url>
@@ -778,10 +1027,13 @@
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/rstcheck.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/sanity-docs.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/runtime-metadata.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/shebang.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/sanity-docs.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/shellcheck.html</loc>
@@ -808,289 +1060,70 @@
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/shell/csh.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/powershell_shell.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/shell/fish.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/replace_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/shell/powershell.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/vars_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/replace_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/lineinfile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lineinfile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/setup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/vars.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/yum_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/setup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/yum_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/apt_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/fetch_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/file_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/copy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/copy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_role_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fetch_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/import_role_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dnf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/script_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/raw_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/dnf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/github_webhook_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/auto_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/github_webhook_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/raw_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_droplet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/assert_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_instance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/ini_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_spanner_instance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/yaml_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_spanner_database_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_dns_resource_record_set_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_dns_managed_zone_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_global_forwarding_rule_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_forwarding_rule_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_health_check_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_http_health_check_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_https_health_check_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_target_http_proxy_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_backend_service_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_url_map_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_compose_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/auto.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/yaml.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/ini.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/say.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_aggregate_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_license_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_lun_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_qtree_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_svm_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_user_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_user_role_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_volume_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_account_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_check_connections_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_access_group_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_snapshot_schedule_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_volume_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_igmp_interface_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/k8s_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/k8s_scale_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_system_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_interface_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nclu_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_net_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_igw_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_route_table_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_subnet_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_nat_gateway_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_dhcp_option_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_nacl_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_ami_facts_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_image_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_container_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_ip_interface_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_l3_interface_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_portchannel_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_linkagg_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_switchport_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_l2_interface_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_security_policy_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_security_rule_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_nat_policy_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_nat_rule_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vsphere_guest_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/stat_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_stat_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/say_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/blockinfile_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_shell_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_command_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualmachine_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_get_url_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_package_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_unzip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/network/index.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/api/index.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/command_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_includes.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/shell_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/unarchive_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/script_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/assemble_module.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing_documentation.html</loc>
@@ -1099,691 +1132,163 @@
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing_pep8.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_securitygroup_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_ironic_node_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_rest_module.html</loc>
-  </url>
-  <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing_compile.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing_units.html</loc>
   </url>
   <url>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing_pep8.html</loc>
+  </url>
+  <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing_running_locally.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/script.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/host_list_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/host_list.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/constructed_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/constructed.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/debug_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/virtualbox.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/_downloads/1e6ed8bafa0a583500674a90c8e55fe5/first_playbook.yml</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/debug_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/_downloads/fdb60d898e1f6601b2c485f977fcb096/first_playbook_ext.yml</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/assert_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/group_by_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_l3_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/core_maintained.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/community_maintained.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/become/doas.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/network_cli_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/become/enable.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/become/dzdo.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/become/ksu.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/cli_parse_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/become/machinectl.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/become/pbrun.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/become/pfexec.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/cli_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/become/pmrun.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing_units_modules.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/become/runas.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_10.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/become/sesu.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/roadmap/COLLECTIONS_2_10.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/become/su.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_9.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/become/sudo.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_8.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cache/memory.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_7.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cache/jsonfile.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_6.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cache/memcached.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_5.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cache/mongodb.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cache/pickle.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cache/redis.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/shell_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cache/yaml.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/log_plays.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/group_by_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/mail.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/meta_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/actionable.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_tasks_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/aws_resource_actions.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/import_tasks_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/cgroup_memory_recap.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/context_demo.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/counter_enabled.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/default.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/cgroup_perf_recap.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/dense.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/foreman.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/full_skip.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/debug.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/grafana_annotations.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/hipchat.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/jabber.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/json.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/junit.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/logdna.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/logentries.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/logstash.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/minimal.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/nrdp.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/null.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/oneline.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/osx_say.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/profile_roles.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/profile_tasks.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/selective.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/skippy.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/slack.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/splunk.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/stderr.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/sumologic.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/syslog_json.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/timer.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/tree.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/unixy.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/callback/yaml.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/aireos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/aruba.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/asa.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/ce.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/cnos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/dellos10.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/dellos6.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/dellos9.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/edgeos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/edgeswitch.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/enos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/eos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/exos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/frr.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/ios.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/iosxr.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/ironware.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/junos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/netvisor.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/nos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/nxos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/onyx.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/routeros.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/slxos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/voss.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/cliconf/vyos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/paramiko_ssh.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/ssh.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/local.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/winrm.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/inventory_hostnames.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/buildah.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/chroot.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/docker.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/funcd.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/httpapi.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/iocage.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/jail.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/kubectl.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/libvirt_lxc.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/lxc.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/lxd.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/napalm.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/netconf.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/network_cli.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/oc.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/persistent.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/podman.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/psrp.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/qubes.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/saltstack.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/zone.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/httpapi/checkpoint.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/httpapi/eos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/httpapi/exos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/httpapi/fortimanager.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/httpapi/ftd.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/httpapi/nxos.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/httpapi/qradar.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/httpapi/restconf.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/httpapi/splunk.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/advanced_host_list.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/aws_ec2.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/aws_rds.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/azure_rm.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/cloudscale.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/docker_swarm.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/foreman.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/gcp_compute.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/generator.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/connection/vmware_tools.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/gitlab_runners.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/hcloud.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/k8s.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/kubevirt.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/linode.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/netbox.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/nmap.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/online.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/openshift.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/openstack.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/scaleway.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/toml.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/tower.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/vmware_vm_inventory.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/inventory/vultr.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/items.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/aws_account_attribute.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/aws_secret.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/aws_service_ip_ranges.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/aws_ssm.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/cartesian.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/chef_databag.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/config.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/conjur_variable.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/consul_kv.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/cpm_metering.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/cpm_status.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/credstash.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/csvfile.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/cyberarkpassword.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/dict.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/dig.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/dnstxt.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/env.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/etcd.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/file.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/fileglob.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/filetree.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/first_found.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/flattened.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/grafana_dashboard.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/hashi_vault.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/hiera.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/indexed_items.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/ini.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/keyring.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/k8s.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/laps_password.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/lastpass.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/lines.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/list.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/manifold.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/mongodb.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/nested.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/nios.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/nios_next_ip.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/nios_next_network.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/onepassword.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/onepassword_raw.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/openshift.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/password.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/passwordstore.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/pipe.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/rabbitmq.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/random_choice.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/redis.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/redis_kv.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/sequence.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/shelvefile.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/skydive.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/subelements.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/template.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/together.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/url.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/lookup/varnames.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/shell/cmd.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/shell/sh.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/strategy/linear.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/strategy/debug.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/strategy/free.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/strategy/host_pinned.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/plugins/vars/host_group_vars.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/unarchive_module.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters_ipaddr.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/assemble_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/async_status_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/linear_strategy.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/debug_strategy.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/free_strategy.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/memory_cache.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/ssh_connection.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/local_connection.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/winrm_connection.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/inventory_hostnames_lookup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/items_lookup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/host_group_vars_vars.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/first_found_lookup.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/style_guide/basic_rules.html</loc>
@@ -1804,19 +1309,7 @@
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/style_guide/resources.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_sshkey_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_compute_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_volume_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/s3_bucket_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_s3_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/dev_guide/style_guide/search_hints.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/vmware_intro.html</loc>
@@ -1828,8227 +1321,13825 @@
     <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/vmware_requirements.html</loc>
   </url>
   <url>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/vmware_inventory_vm_attributes.html</loc>
+  </url>
+  <url>
     <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/vmware_inventory.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/vmware_inventory_hostnames.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/vmware_inventory_filters.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/vmware_scenarios.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/vmware_troubleshooting.html</loc>
-  </url>
-  <url>
     <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/vmware_external_doc_links.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_network_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/a10_server_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/a10_server_axapi3_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/a10_service_group_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/a10_virtual_server_module.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_aaa_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/vmware_troubleshooting.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/inventory/implicit_localhost.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_aaa_user_certificate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_ec2_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_access_port_block_to_access_port_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_eapi_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_access_port_to_interface_policy_leaf_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/netconf_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_access_sub_port_block_to_access_port_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_resource_actions_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_aep_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_secret_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_aep_to_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_rds_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_ap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_account_attribute_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_bd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_service_ip_ranges_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_bd_subnet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_ssm_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_bd_to_l3out_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_az_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_config_rollback_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_caller_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_contract_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_az_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_config_snapshot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_caller_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_contract_subject_to_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_s3_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_contract_subject_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/cloudformation_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/cloudformation_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_domain_to_encap_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/cloudformation_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_domain_to_vlan_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_encap_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_ami_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_encap_pool_range_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_ami_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_epg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_ami_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_epg_monitoring_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_elb_lb_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_epg_to_contract_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_eni_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_epg_to_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_eni_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_fabric_node_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_eni_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_fabric_scheduler_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_group_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_filter_entry_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_group_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_firmware_group_node_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_metadata_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_firmware_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_snapshot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_firmware_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_key_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_firmware_source_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_snapshot_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_interface_policy_fc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_snapshot_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_interface_policy_l2_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_tag_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_interface_policy_leaf_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_tag_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_interface_policy_leaf_policy_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_vol_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_interface_policy_lldp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_vol_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_interface_policy_mcp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_vpc_dhcp_option_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_interface_policy_ospf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_vol_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_interface_policy_port_channel_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_vpc_dhcp_option_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_interface_policy_port_security_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_vpc_dhcp_option_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_interface_selector_to_switch_policy_leaf_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_vpc_net_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_l3out_route_tag_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_vpc_net_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_l3out_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_vpc_net_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_maintenance_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_vpc_subnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_maintenance_group_node_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_vpc_subnet_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_static_binding_to_epg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_vpc_subnet_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_maintenance_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/runas_become.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_switch_leaf_selector_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/amazon/aws/s3_bucket_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_switch_policy_leaf_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/su_become.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_switch_policy_vpc_protection_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/sudo_become.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_taboo_contract_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/jsonfile_cache.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_tenant_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/minimal_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_tenant_action_rule_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/default_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_tenant_ep_retention_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/junit_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_tenant_span_dst_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/tree_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_tenant_span_src_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/oneline_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_tenant_span_src_group_to_dst_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/paramiko_ssh_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_vlan_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/psrp_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_vlan_pool_encap_block_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/generator_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aci_vrf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/advanced_host_list_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_label_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/script_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/toml_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/config_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_site_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/csvfile_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_site_anp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/dict_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_site_anp_epg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/env_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_site_anp_epg_staticleaf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_site_anp_epg_subnet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/fileglob_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_site_anp_epg_staticport_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/indexed_items_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_site_bd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/ini_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_site_bd_subnet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/lines_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_site_bd_l3out_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/list_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_site_vrf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/nested_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_site_vrf_region_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/random_choice_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_site_vrf_region_cidr_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/password_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_site_vrf_region_cidr_subnet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pipe_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/sequence_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_template_anp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/subelements_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_template_anp_epg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/template_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_template_anp_epg_contract_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/together_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_template_bd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/unvault_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_template_anp_epg_subnet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/varnames_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_template_contract_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/add_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_template_bd_subnet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/url_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_template_deploy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_key_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_template_externalepg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/blockinfile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_template_filter_entry_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/cron_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_template_l3out_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/debconf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_schema_template_vrf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_repository_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_site_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/dpkg_selections_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_tenant_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/expect_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mso_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/fail_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aireos_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/gather_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aireos_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/find_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aos_asn_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aos_blueprint_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/git_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aos_blueprint_param_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/getent_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aos_blueprint_virtnet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aos_device_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/hostname_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aos_external_router_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/import_playbook_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aos_ip_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/iptables_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aos_logical_device_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/known_hosts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aos_logical_device_map_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aos_login_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aos_rack_type_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pause_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aos_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/ping_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aruba_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aruba_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/reboot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/asa_acl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/rpm_key_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/asa_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/service_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/asa_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/service_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/asa_og_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/slurp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_actiongroupconfig_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/set_stats_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_alertconfig_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/stat_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_alertemailconfig_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/subversion_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_alertscriptconfig_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/systemd_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_alertsyslogconfig_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/sysvinit_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_analyticsprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/tempfile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_api_session_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_api_version_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/wait_for_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_applicationpersistenceprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/wait_for_connection_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_applicationprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/yum_repository_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_authprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/sh_shell.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_autoscalelaunchconfig_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/cmd_shell.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_backup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/host_pinned_strategy.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_backupconfiguration_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/enable_become.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_certificatemanagementprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/httpapi_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_cloud_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/libssh_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_cloudconnectoruser_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/napalm_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_cloudproperties_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/persistent_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/restconf_httpapi.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_clusterclouddetails_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/cli_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_controllerproperties_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_banner_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_customipamdnsprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_get_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_dnspolicy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_errorpagebody_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_l2_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_errorpageprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_linkagg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_gslb_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_l3_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_gslbapplicationpersistenceprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_lldp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_gslbgeodbprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_lldp_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_gslbhealthmonitor_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_logging_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_gslbservice_patch_member_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_ping_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_gslbservice_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_put_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_hardwaresecuritymodulegroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_static_route_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_healthmonitor_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_system_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_httppolicyset_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_ipaddrgroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_l4policyset_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/net_vrf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_ipamdnsproviderprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/netconf_get_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_microservicegroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/netconf_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/netconf_rpc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_networkprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/restconf_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_networksecuritypolicy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/restconf_get_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_pkiprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/telnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_poolgroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/default_netconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/cgroup_perf_recap_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_poolgroupdeploymentpolicy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/debug_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_prioritylabels_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/json_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/profile_roles_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_scheduler_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/profile_tasks_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_seproperties_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/skippy_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_serverautoscalepolicy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/timer_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_serviceengine_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/acl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_serviceenginegroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/authorized_key_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_snmptrapprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/at_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_sslkeyandcertificate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/mount_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_sslprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/firewalld_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_stringgroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/seboolean_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_systemconfiguration_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/patch_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_tenant_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/selinux_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_trafficcloneprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/synchronize_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_useraccount_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/sysctl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_useraccountprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/csh_shell.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_virtualservice_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/posix/fish_shell.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_vrfcontext_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_acl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_vsdatascriptset_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_acl_inheritance_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_vsvip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_wafpolicy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_certificate_store_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_wafprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_copy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/avi_webhook_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_dns_client_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigmon_chain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_domain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bcf_switch_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_domain_controller_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigmon_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_domain_membership_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/checkpoint_access_layer_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_dsc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/checkpoint_access_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_environment_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/checkpoint_object_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_file_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/checkpoint_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_feature_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/checkpoint_access_rule_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_find_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/checkpoint_run_script_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_get_url_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/checkpoint_session_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/checkpoint_host_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_group_membership_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/checkpoint_task_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_hostname_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cli_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_optional_feature_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cli_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_owner_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_aaa_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_package_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_aaa_server_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_path_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_acl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_reboot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_acl_advance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_ping_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_acl_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_regedit_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_bfd_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_reg_stat_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_bfd_session_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_service_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_bfd_view_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_service_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_bgp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_share_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_bgp_af_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_shell_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_bgp_neighbor_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_stat_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_bgp_neighbor_af_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_tempfile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_updates_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_dldp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_uri_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_dldp_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_eth_trunk_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_user_right_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_evpn_bd_vni_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_wait_for_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_evpn_bgp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_whoami_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_evpn_bgp_rr_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_evpn_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_httpapi.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_acl_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_file_copy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_acls_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_info_center_debug_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_banner_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_info_center_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_info_center_log_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_bgp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_info_center_trap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_l2_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_interface_ospf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_l2_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_ip_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_lacp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_link_status_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_l3_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_mlag_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_lacp_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_mlag_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_lag_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_mtu_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_linkagg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_netconf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_lldp_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_netstream_aging_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_lldp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_netstream_export_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_lldp_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_netstream_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_logging_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_netstream_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_ospfv2_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_ntp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_static_routes_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_ntp_auth_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_static_route_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_ospf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_system_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_ospf_vrf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_reboot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_rollback_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_vlans_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_sflow_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_vrf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_snmp_community_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_snmp_contact_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_api_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_snmp_location_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_schedule_rrule_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_snmp_target_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_credential_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_snmp_traps_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_credential_input_source_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_snmp_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_credential_type_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_startup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_export_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_static_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_stp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_switchport_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_import_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_inventory_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_vrf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_inventory_source_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_vrf_af_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_job_cancel_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_vrf_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_job_list_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_vrrp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_job_launch_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_vxlan_arp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_job_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_vxlan_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_job_wait_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_vxlan_gateway_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_label_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_vxlan_tunnel_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_license_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ce_vxlan_vap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_meta_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cv_server_provision_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_notification_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_banner_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_receive_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_backup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_organization_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_bgp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_project_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_role_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_conditional_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_schedule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_conditional_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_team_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_send_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_factory_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_settings_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_workflow_job_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_image_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_token_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_l2_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_workflow_job_template_node_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_l3_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_workflow_launch_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_linkagg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_workflow_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_lldp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_logging_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_adpassword_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_reload_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_adserviceprincipal_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_rollback_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_adpassword_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_save_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_adserviceprincipal_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_showrun_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_aks_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_static_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_aks_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_system_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_aksversion_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_appgateway_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_applicationsecuritygroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_vlag_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_applicationsecuritygroup_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_appserviceplan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cnos_vrf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_appserviceplan_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dellos10_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_automationaccount_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dellos10_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_automationaccount_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dellos10_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_autoscale_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dellos6_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_autoscale_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dellos6_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_availabilityset_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dellos6_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_availabilityset_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dellos9_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_azurefirewall_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dellos9_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_batchaccount_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/edgeos_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_cdnendpoint_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/edgeos_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_azurefirewall_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/edgeos_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_cdnprofile_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/edgeswitch_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_cdnendpoint_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/edgeswitch_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_cdnprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/enos_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_containerinstance_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/enos_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_containerinstance_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/enos_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_containerregistry_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_banner_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_containerregistry_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_bgp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_containerregistryreplication_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_containerregistryreplication_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_containerregistrywebhook_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_eapi_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_containerregistrywebhook_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_cosmosdbaccount_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_cosmosdbaccount_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_l2_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_deployment_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_l3_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlab_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_linkagg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_deployment_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_lldp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabarmtemplate_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dellos9_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlab_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_logging_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabartifact_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_static_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabartifactsource_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_system_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabartifactsource_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabcustomimage_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabcustomimage_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/eos_vrf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabenvironment_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/exos_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabenvironment_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/exos_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabpolicy_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/exos_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabpolicy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_apm_policy_fetch_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabschedule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_apm_policy_import_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabschedule_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_appsvcs_extension_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabvirtualmachine_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_asm_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabvirtualmachine_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_asm_policy_fetch_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabvirtualnetwork_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_asm_policy_import_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_dnsrecordset_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_asm_policy_manage_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_devtestlabvirtualnetwork_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_asm_policy_server_technology_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_dnsrecordset_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_asm_policy_signature_set_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_dnszone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_cli_alias_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_functionapp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_cli_script_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_dnszone_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_functionapp_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_gallery_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_configsync_action_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_gallery_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_data_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_galleryimage_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_auth_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_galleryimage_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_auth_ldap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_galleryimageversion_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_connectivity_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_hdinsightcluster_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_dns_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_galleryimageversion_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_image_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_hdinsightcluster_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_group_member_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_iotdevice_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_ha_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_iotdevice_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_httpd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_image_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_license_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_iotdevicemodule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_ntp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_iothub_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_sshd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_iothub_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_syslog_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_iothubconsumergroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_traffic_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_keyvault_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_device_trust_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_keyvault_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_dns_cache_resolver_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_keyvaultkey_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_dns_nameserver_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_keyvaultkey_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_dns_zone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_keyvaultsecret_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_dns_resolver_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_keyvaultsecret_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_loadbalancer_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_file_copy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_loadbalancer_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_firewall_address_list_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_lock_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_firewall_dos_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_lock_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_firewall_dos_vector_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_loganalyticsworkspace_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_firewall_global_rules_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_loganalyticsworkspace_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_firewall_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_manageddisk_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_firewall_port_list_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_manageddisk_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_firewall_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_managementgroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_firewall_rule_list_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mariadbconfiguration_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_datacenter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mariadbconfiguration_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mariadbdatabase_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mariadbdatabase_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_monitor_external_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mariadbfirewallrule_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_monitor_bigip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mariadbfirewallrule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_monitor_firepass_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mariadbserver_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_monitor_http_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mariadbserver_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_monitor_https_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_monitorlogprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_monitor_tcp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mysqlconfiguration_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_monitor_tcp_half_open_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mysqlconfiguration_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mysqldatabase_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_pool_member_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mysqldatabase_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mysqlfirewallrule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_topology_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mysqlfirewallrule_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_topology_region_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mysqlserver_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_virtual_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_mysqlserver_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_gtm_wide_ip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_networkinterface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_hostname_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_networkinterface_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_iapp_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_postgresqlconfiguration_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_iapp_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_postgresqldatabase_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_imish_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_postgresqlconfiguration_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_ike_peer_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_postgresqldatabase_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_ipsec_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_postgresqlfirewallrule_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_irule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_postgresqlfirewallrule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_log_destination_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_postgresqlserver_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_log_publisher_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_postgresqlserver_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_lx_package_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_privatednszone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_management_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_privatednszone_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_monitor_dns_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_publicipaddress_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_monitor_external_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_publicipaddress_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_monitor_gateway_icmp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_rediscache_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_monitor_http_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_rediscachefirewallrule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_monitor_https_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_rediscache_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_monitor_ldap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_resource_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_monitor_snmp_dca_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_resource_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_monitor_tcp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_resourcegroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_monitor_tcp_echo_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_resourcegroup_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_monitor_tcp_half_open_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_roleassignment_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_monitor_udp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_roleassignment_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_node_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_roledefinition_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_partition_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_route_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_policy_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_roledefinition_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_password_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_routetable_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_pool_member_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_routetable_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_securitygroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_profile_analytics_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_securitygroup_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_profile_client_ssl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_servicebus_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_servicebus_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_profile_dns_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_servicebusqueue_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_profile_fastl4_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_servicebussaspolicy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_profile_http_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_servicebustopicsubscription_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_profile_http2_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_servicebustopic_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_profile_http_compression_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_snapshot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_profile_oneconnect_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_sqldatabase_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_profile_persistence_cookie_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_sqldatabase_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_profile_server_ssl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_sqlfirewallrule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_profile_persistence_src_addr_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_sqlfirewallrule_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_profile_tcp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_sqlserver_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_provision_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_sqlserver_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_profile_udp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_storageaccount_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_qkview_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_storageaccount_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_remote_syslog_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_storageblob_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_remote_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_subnet_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_routedomain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_subnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_selfip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_trafficmanager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_service_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_trafficmanagerendpoint_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_smtp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_trafficmanagerendpoint_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_snat_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_trafficmanagerprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_snmp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_trafficmanagerprofile_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_snmp_community_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualmachine_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_snmp_trap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualmachine_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_software_image_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualmachineextension_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_software_update_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualmachineimage_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_software_install_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualmachineextension_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_ssl_certificate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualmachinescaleset_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_ssl_ocsp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualmachinescaleset_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_static_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualmachinescalesetextension_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_sys_daemon_log_tmm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualmachinescalesetextension_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_sys_db_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualmachinescalesetinstance_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_timer_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualmachinescalesetinstance_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_sys_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualnetwork_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_traffic_selector_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualnetwork_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_trunk_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualnetworkgateway_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_tunnel_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualnetworkpeering_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_ucs_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualnetworkpeering_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_ucs_fetch_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_webapp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_webapp_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_vcmp_guest_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/checkpoint_httpapi.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_virtual_address_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_webappslot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_virtual_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/checkpoint_access_layer_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/checkpoint_access_rule_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_wait_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/checkpoint_access_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigiq_application_fasthttp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/checkpoint_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigip_ssl_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/checkpoint_host_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigiq_application_fastl4_tcp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/checkpoint_object_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigiq_application_fastl4_udp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/checkpoint_run_script_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigiq_application_http_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/checkpoint_session_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigiq_application_https_offload_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/checkpoint_task_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigiq_application_https_waf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_access_layer_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigiq_device_discovery_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_access_layer_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigiq_device_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_access_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigiq_regkey_license_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_access_role_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigiq_regkey_license_assignment_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_access_rule_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigiq_regkey_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_access_role_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigiq_utility_license_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_access_section_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigiq_utility_license_assignment_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_add_data_center_object_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_get_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_add_api_key_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_put_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_address_range_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_device_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_add_nat_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_device_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_address_range_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_device_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_administrator_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_device_provision_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_administrator_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_fwobj_address_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_application_site_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_fwobj_ippool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_application_site_category_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_fwobj_ippool6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_application_site_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_fwobj_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_application_site_category_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_fwpol_ipv4_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_application_site_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_fwobj_vip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_application_site_group_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_fwpol_package_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_assign_global_assignment_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_ha_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_data_center_object_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_provisioning_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_delete_api_key_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_query_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_delete_data_center_object_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_script_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_delete_nat_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_secprof_appctrl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_discard_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_secprof_av_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_dns_domain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_secprof_dns_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_dns_domain_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_secprof_ips_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_dynamic_object_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_secprof_profile_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_dynamic_object_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_secprof_proxy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_exception_group_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_secprof_spam_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_exception_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_secprof_ssl_ssh_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_global_assignment_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_secprof_voip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_global_assignment_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_secprof_waf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_secprof_wanopt_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_group_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fmgr_secprof_web_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_group_with_exclusion_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_address_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_group_with_exclusion_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_antivirus_heuristic_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_antivirus_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_https_section_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_antivirus_quarantine_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_host_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_antivirus_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_install_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_application_custom_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_install_software_package_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_application_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_mds_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_application_list_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_multicast_address_range_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_application_name_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_multicast_address_range_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_application_rule_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_nat_rule_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_authentication_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_nat_section_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_authentication_scheme_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_network_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_authentication_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_package_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_dlp_filepattern_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_package_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_dlp_fp_doc_source_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_publish_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_dlp_fp_sensitivity_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_run_ips_update_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_dlp_sensor_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_put_file_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_dlp_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_run_script_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_dnsfilter_domain_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_security_zone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_dnsfilter_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_dce_rpc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_endpoint_control_forticlient_ems_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_security_zone_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_endpoint_control_client_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_endpoint_control_forticlient_registration_sync_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_dce_rpc_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_endpoint_control_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_icmp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_endpoint_control_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_group_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_address_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_icmp6_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_extender_controller_extender_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_other_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_address6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_icmp6_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_address6_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_icmp_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_addrgrp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_other_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_addrgrp6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_rpc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_auth_portal_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_rpc_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_central_snat_map_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_sctp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_dnstranslation_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_sctp_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_DoS_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_tcp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_DoS_policy6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_tcp_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_identity_based_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_udp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_interface_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_service_udp_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_interface_policy6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_session_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_internet_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_set_nat_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_internet_service_custom_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_show_access_section_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_internet_service_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_show_https_section_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ip_translation_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_show_nat_section_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ipmacbinding_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_show_software_package_details_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ipmacbinding_table_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_show_task_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ippool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_show_tasks_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ippool6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_simple_gateway_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ipv6_eh_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_simple_gateway_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ldb_monitor_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_tag_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_local_in_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_tag_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_local_in_policy6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_threat_exception_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_multicast_address_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_threat_exception_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_multicast_address6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_threat_indicator_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_multicast_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_threat_indicator_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_multicast_policy6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_threat_layer_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_threat_layer_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_policy46_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_threat_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_policy6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_threat_profile_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_policy64_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_threat_protection_override_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_profile_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_threat_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_profile_protocol_options_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_threat_rule_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_proxy_address_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_time_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_proxy_addrgrp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_time_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_proxy_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_uninstall_software_package_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_schedule_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_verify_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_schedule_onetime_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_vpn_community_meshed_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_schedule_recurring_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_verify_software_package_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_service_category_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_vpn_community_meshed_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_service_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_vpn_community_star_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_service_custom_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_vpn_community_star_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_shaper_per_ip_shaper_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_wildcard_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_shaper_traffic_shaper_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/check_point/mgmt/cp_mgmt_wildcard_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_shaping_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/chocolatey/chocolatey/win_chocolatey_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_shaping_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/chocolatey/chocolatey/win_chocolatey_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_sniffer_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/chocolatey/chocolatey/win_chocolatey_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ssh_host_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/chocolatey/chocolatey/win_chocolatey_feature_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ssh_local_ca_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/chocolatey/chocolatey/win_chocolatey_source_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ssh_local_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_aaa_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ssh_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_aaa_user_certificate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ssl_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_access_port_to_interface_policy_leaf_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ssl_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_access_port_block_to_access_port_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ssl_ssh_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_access_sub_port_block_to_access_port_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_vip46_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_aep_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_ttl_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_aep_to_domain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_vip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_ap_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_vipgrp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_bd_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_vip64_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_bd_dhcp_label_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_vip6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_bd_subnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_vipgrp6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_bd_to_l3out_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_vipgrp64_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_cloud_cidr_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_wildcard_fqdn_custom_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_cloud_provider_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_vipgrp46_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_cloud_ctx_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_firewall_wildcard_fqdn_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_cloud_subnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_ftp_proxy_explicit_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_cloud_region_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_icap_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_cloud_vpn_gateway_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_icap_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_cloud_zone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_ips_custom_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_config_snapshot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_ips_decoder_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_config_rollback_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_ips_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_contract_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_ips_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_contract_subject_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_ips_rule_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_domain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_ips_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_contract_subject_to_filter_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_ips_sensor_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_domain_to_vlan_pool_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_ipv4_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_domain_to_encap_pool_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_custom_field_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_encap_pool_range_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_disk_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_encap_pool_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_disk_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_epg_monitoring_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_fortianalyzer2_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_epg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_eventfilter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_epg_to_contract_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_fortianalyzer2_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_epg_to_contract_master_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_fortianalyzer3_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_fabric_node_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_fortianalyzer3_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_epg_to_domain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_fortianalyzer_override_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_fabric_scheduler_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_fortianalyzer_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_filter_entry_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_fortianalyzer_override_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_filter_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_fortianalyzer_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_firmware_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_fortiguard_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_firmware_group_node_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_fortiguard_override_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_firmware_source_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_fortiguard_override_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_firmware_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_fortiguard_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_interface_policy_cdp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_gui_display_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_interface_policy_leaf_policy_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_memory_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_interface_policy_fc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_memory_global_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_interface_policy_mcp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_memory_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_interface_policy_l2_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_null_device_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_interface_policy_leaf_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_null_device_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_interface_policy_ospf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_interface_policy_link_level_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_syslogd2_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_interface_policy_port_security_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_syslogd2_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_interface_policy_lldp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_syslogd3_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_interface_policy_port_channel_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_syslogd3_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_l2out_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_syslogd4_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_interface_selector_to_switch_policy_leaf_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_syslogd4_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_l3out_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_syslogd_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_l2out_extepg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_syslogd_override_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_l3out_extepg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_syslogd_override_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_l3out_extepg_to_contract_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_syslogd_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_l3out_extsubnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_threat_weight_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_l3out_route_tag_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_webtrends_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_maintenance_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_log_webtrends_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_maintenance_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_report_chart_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_maintenance_group_node_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_report_dataset_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_rest_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_report_layout_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_switch_policy_leaf_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_report_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_static_binding_to_epg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_report_style_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_switch_leaf_selector_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_access_list_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_switch_policy_vpc_protection_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_bfd6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_system_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_bfd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_taboo_contract_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_auth_path_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_tenant_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_multicast_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_tenant_action_rule_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_multicast6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_tenant_ep_retention_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_multicast_flow_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_tenant_span_src_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_bgp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_tenant_span_dst_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_report_theme_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_vlan_pool_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_ospf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_tenant_span_src_group_to_dst_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_ospf6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_vlan_pool_encap_block_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_policy6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_vmm_credential_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/asa/asa_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_prefix_list_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/aci/aci_vrf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_rip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/asa/asa_acl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/asa/asa_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_router_static_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/asa/asa_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_spamfilter_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/asa/asa_acls_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_ssh_filter_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/asa/asa_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_switch_controller_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/asa/asa_og_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_switch_controller_lldp_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/asa/asa_ogs_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_switch_controller_lldp_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/intersight/intersight_boot_order_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_switch_controller_mac_sync_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/intersight/intersight_imc_access_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_switch_controller_managed_switch_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/intersight/intersight_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_switch_controller_network_monitor_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/intersight/intersight_ntp_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_system_accprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/intersight/intersight_rest_api_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_system_admin_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/intersight/intersight_server_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_system_api_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_system_central_management_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/intersight/intersight_virtual_media_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_system_dhcp_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_acl_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_system_dns_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_banner_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_system_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_acls_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_system_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_bgp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_system_sdn_connector_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_system_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_system_vdom_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_system_virtual_wan_link_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_l2_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_user_adgrp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_l2_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_user_radius_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_l3_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_user_tacacsplus_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_lacp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_voip_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_l3_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_vpn_ipsec_concentrator_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_lacp_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_vpn_ipsec_forticlient_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_linkagg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_vpn_ipsec_manualkey_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_lldp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_vpn_ipsec_manualkey_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_lag_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_vpn_ipsec_phase1_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_lldp_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_vpn_ipsec_phase1_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_lldp_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_vpn_ipsec_phase2_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_logging_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_vpn_ssl_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_ping_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_vpn_ipsec_phase2_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_ntp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_vpn_ssl_web_portal_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_ospfv2_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_waf_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_static_route_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_wanopt_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_static_routes_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_wanopt_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_system_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_web_proxy_explicit_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_web_proxy_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_web_proxy_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_vlans_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_webfilter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_webfilter_content_header_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ios/ios_vrf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_webfilter_content_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_acls_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_webfilter_fortiguard_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_acl_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_webfilter_ftgd_local_cat_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_banner_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_webfilter_ftgd_local_rating_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_webfilter_ips_urlfilter_cache_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_bgp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_webfilter_ips_urlfilter_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_webfilter_ips_urlfilter_setting6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_webfilter_override_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_webfilter_search_engine_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_webfilter_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_l2_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_webfilter_urlfilter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_l3_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_wireless_controller_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_lacp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_wireless_controller_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_lacp_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_wireless_controller_utm_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_lldp_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_wireless_controller_vap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_lag_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_wireless_controller_wtp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_lldp_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_wireless_controller_wids_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_logging_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fortios_wireless_controller_wtp_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_netconf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/frr_bgp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_ospfv2_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/frr_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_static_routes_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ftd_configuration_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_system_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ftd_file_download_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ftd_file_upload_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_admin_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ftd_install_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/iosxr/iosxr_netconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dladm_etherstub_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_config_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dladm_iptun_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_device_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dladm_linkprop_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_content_filtering_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dladm_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_firewalled_services_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dladm_vnic_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_intrusion_prevention_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/flowadm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_malware_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipadm_addr_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_management_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipadm_addrprop_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mr_l3_firewall_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipadm_if_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mr_rf_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipadm_ifprop_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mr_settings_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipadm_prop_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mr_ssid_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ig_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_ms_access_list_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ig_unit_information_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_ms_l3_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_ms_link_aggregation_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_linkagg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_ms_stack_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_lldp_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_ms_storm_control_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_banner_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_ms_ospf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_ms_switchport_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_bgp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mx_content_filtering_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mx_intrusion_prevention_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mx_l3_firewall_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mx_l7_firewall_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_l3_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mx_malware_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_l2_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mx_nat_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_linkagg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mx_site_to_site_vpn_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_lldp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mx_site_to_site_firewall_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_logging_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mx_static_route_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_ntp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mx_uplink_bandwidth_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_ping_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mx_uplink_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_system_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_mx_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_static_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_nat_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_vrf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_organization_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iosxr_banner_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_site_to_site_vpn_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iosxr_bgp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_snmp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iosxr_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_static_route_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iosxr_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_ssid_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iosxr_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_switch_access_list_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iosxr_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_switch_stack_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iosxr_logging_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_switch_storm_control_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iosxr_netconf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_switchport_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iosxr_system_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_syslog_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iosxr_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ironware_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/meraki/meraki_webhook_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ironware_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_backup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ironware_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_label_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iap_start_workflow_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_role_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iap_token_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_banner_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_anp_epg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ios_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_anp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_anp_epg_domain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_anp_epg_selector_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_anp_epg_staticport_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_l2_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_anp_epg_staticleaf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_l3_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_anp_epg_subnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_linkagg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_bd_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_lldp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_bd_l3out_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_lldp_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_bd_subnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_logging_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_external_epg_selector_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_netconf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_vrf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_package_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_vrf_region_cidr_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_ping_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_vrf_region_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_rpc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_vrf_region_cidr_subnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_scp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_site_vrf_region_hub_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_static_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_system_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_anp_epg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_anp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_anp_epg_contract_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/junos_vrf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_anp_epg_selector_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_l2_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_anp_epg_subnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_bd_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_l3_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_bd_subnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_vrf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_contract_filter_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_admin_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_deploy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_config_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_external_epg_contract_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_content_filtering_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_external_epg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_mr_l3_firewall_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_external_epg_selector_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_device_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_external_epg_subnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_mx_l3_firewall_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_externalepg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_l3out_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_organization_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_filter_entry_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_snmp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_vrf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_ssid_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_schema_template_vrf_contract_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_static_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_site_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_switchport_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_tenant_site_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_syslog_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_tenant_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meraki_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netact_cm_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/mso/mso_version_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netconf_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netconf_get_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_httpapi.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netconf_rpc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_aaa_server_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_cs_action_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_aaa_server_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_cs_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_acl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_cs_vserver_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_acl_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_gslb_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_acl_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_gslb_site_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_acls_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_gslb_vserver_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_banner_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_lb_monitor_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_bfd_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_nitro_request_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_bfd_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_lb_vserver_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_bgp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_save_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_bgp_af_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_bgp_neighbor_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_bgp_neighbor_af_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_servicegroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_devicealias_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netscaler_ssl_certkey_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_access_list_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_evpn_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_access_list_ip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_evpn_vni_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_admin_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_feature_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_admin_session_timeout_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_admin_syslog_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_file_copy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_gir_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_connection_stats_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_hsrp_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_cpu_class_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_gir_profile_management_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_cpu_mgmt_class_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_igmp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_dhcp_filter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_hsrp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_dscp_map_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_igmp_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_dscp_map_pri_map_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_igmp_snooping_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_igmp_snooping_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_ospf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_interface_ospf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_ospfarea_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_install_os_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_port_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_l2_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_port_cos_bw_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_port_cos_rate_setting_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_l2_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_prefix_list_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_l3_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_l3_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_show_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_lacp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_snmp_community_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_lag_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_snmp_trap_sink_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_lacp_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_snmp_vacm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_linkagg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_stp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_lldp_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_stp_port_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_lldp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_switch_setup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_lldp_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_trunk_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_logging_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_ntp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_vflow_table_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_ntp_auth_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_vlag_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_ntp_options_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_nxapi_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_vrouter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_ospf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_vrouter_bgp_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_ospf_vrf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_vrouter_interface_ip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_ospfv2_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_vrouter_ospf6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_pim_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_vrouter_pim_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_overlay_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_vrouterbgp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_pim_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_vrouterlbif_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_pim_rp_address_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pn_vrouterif_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_ping_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nos_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_rollback_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nos_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_reboot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nos_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_rpm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nso_action_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_snapshot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nso_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_smu_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nso_query_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_snmp_community_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nso_show_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_snmp_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nso_verify_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_snmp_contact_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nuage_vspk_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_snmp_location_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_aaa_server_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_snmp_traps_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_aaa_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_snmp_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_acl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_system_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_acl_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_static_route_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_banner_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_static_routes_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_bgp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_telemetry_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_bgp_af_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_udld_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_bgp_neighbor_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_udld_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_bgp_neighbor_af_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_evpn_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vlans_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vpc_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_evpn_vni_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vpc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vrf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_feature_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vrf_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_file_copy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vrf_af_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_gir_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vsan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_gir_profile_management_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vrrp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_hsrp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vtp_domain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_igmp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vtp_password_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_igmp_snooping_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vtp_version_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_install_os_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vxlan_vtep_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_interface_ospf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_vxlan_vtep_vni_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_lldp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/nxos/nxos_zone_zoneset_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_logging_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_disk_group_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_ntp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_dns_server_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_ntp_auth_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_graphics_card_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_ntp_options_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_ip_pool_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_nxapi_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_lan_connectivity_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_ospf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_mac_pool_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_ospf_vrf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_managed_objects_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_overlay_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_ntp_server_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_pim_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_org_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_pim_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_query_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_pim_rp_address_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_san_connectivity_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_ping_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_scrub_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_reboot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_serial_over_lan_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_rollback_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_service_profile_from_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_rpm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_service_profile_association_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_snapshot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_service_profile_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_smu_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_sp_vnic_order_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_snmp_community_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_system_qos_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_snmp_contact_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_storage_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_snmp_location_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_timezone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_snmp_traps_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_uuid_pool_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_snmp_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_vhba_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_snmp_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_vlan_find_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_static_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_vlan_to_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_udld_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_vnic_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_udld_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_vlans_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_vsans_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cisco/ucs/ucs_wwn_pool_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_vpc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cloudscale_ch/cloud/inventory_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_vpc_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cloudscale_ch/cloud/floating_ip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_vrf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cloudscale_ch/cloud/objects_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_vrf_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cloudscale_ch/cloud/server_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_vrf_af_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cloudscale_ch/cloud/server_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_vrrp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cloudscale_ch/cloud/volume_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_vtp_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_ssm_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_vtp_version_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_acm_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_vtp_password_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_acm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_vxlan_vtep_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_acm_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_bgp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_application_scaling_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_buffer_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_api_gateway_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_batch_job_definition_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_igmp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_batch_compute_environment_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nxos_vxlan_vtep_vni_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_batch_job_queue_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_codecommit_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_igmp_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_codebuild_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_codepipeline_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_l2_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_config_aggregator_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_l3_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_config_aggregation_authorization_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_config_delivery_channel_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_igmp_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_config_recorder_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_linkagg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_direct_connect_confirm_connection_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_lldp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_config_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_lldp_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_direct_connect_connection_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_mlag_ipl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_direct_connect_link_aggregation_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_magp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_direct_connect_gateway_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_mlag_vip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_direct_connect_virtual_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_ospf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_eks_cluster_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_pfc_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_elasticbeanstalk_app_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_protocol_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_glue_connection_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_ptp_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_glue_job_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_ptp_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_inspector_target_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_kms_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onyx_vxlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_kms_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/opx_cps_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_kms_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ordnance_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_region_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ordnance_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_region_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openvswitch_bridge_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_s3_bucket_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openvswitch_db_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_s3_bucket_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openvswitch_port_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_s3_cors_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_admin_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_secret_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_admpwd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_ses_identity_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_cert_gen_ssh_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_ses_identity_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_check_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_sgw_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_commit_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_sgw_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_dag_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_ses_rule_set_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_dag_tags_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_step_functions_state_machine_execution_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_import_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_waf_condition_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_ssm_parameter_store_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_lic_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_waf_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_mgtconfig_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_step_functions_state_machine_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_object_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_waf_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_op_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_waf_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_loadcfg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/cloudformation_exports_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_query_rules_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/aws_waf_web_acl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_match_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/cloudformation_stack_set_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_pg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/cloudfront_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_restart_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/cloudfront_distribution_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_sag_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/cloudfront_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/panos_set_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/cloudfront_invalidation_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_lldp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/cloudfront_origin_access_identity_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vdirect_commit_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/cloudtrail_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vdirect_file_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/cloudwatchevent_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vdirect_runnable_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/cloudwatchlogs_log_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/restconf_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/cloudwatchlogs_log_group_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/restconf_get_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/cloudwatchlogs_log_group_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/routeros_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/cloudwatchlogs_log_group_metric_filter_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/routeros_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/dms_endpoint_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_static_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/data_pipeline_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/skydive_capture_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/dms_replication_subnet_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/skydive_edge_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/dynamodb_table_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/skydive_node_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/dynamodb_ttl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/slxos_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_ami_copy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/slxos_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_asg_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/slxos_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_asg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/slxos_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_asg_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/slxos_l2_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_asg_lifecycle_hook_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/slxos_l3_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_customer_gateway_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/slxos_linkagg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_customer_gateway_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/slxos_lldp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_customer_gateway_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/slxos_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_eip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sros_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_eip_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sros_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_eip_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sros_rollback_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_elb_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_logging_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_elb_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_banner_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_elb_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_system_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_instance_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_ping_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_instance_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/net_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_launch_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/voss_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_instance_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/voss_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_lc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/voss_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_lc_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_banner_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_lc_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_lc_find_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_metric_alarm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_scaling_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_placement_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_l3_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_snapshot_copy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_linkagg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_placement_group_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_lldp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_placement_group_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_logging_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_transit_gateway_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_ping_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_transit_gateway_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_static_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_endpoint_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_system_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_egress_igw_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_endpoint_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_endpoint_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/_downloads/first_playbook.yml</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_igw_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/_downloads/first_playbook_ext.yml</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_igw_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/acl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_nacl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/acme_account_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_igw_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/acme_account_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_nacl_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/acme_certificate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_nacl_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/acme_certificate_revoke_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_nat_gateway_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/acme_challenge_cert_helper_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_nat_gateway_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/add_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_peer_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/acme_inspect_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_nat_gateway_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aerospike_migrations_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_peering_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/airbrake_deployment_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_peering_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aix_devices_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_route_table_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vyos_lldp_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_route_table_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aix_filesystem_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_route_table_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aix_inittab_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_vgw_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aix_lvg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_vgw_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aix_lvol_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_vgw_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ali_instance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_vpn_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ali_instance_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_vpn_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/alternatives_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_vpc_vpn_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/apache2_mod_proxy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ec2_win_password_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/apache2_module_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ecs_attribute_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/apk_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ecs_cluster_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/apt_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ecs_service_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/apt_repo_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ecs_ecr_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/apt_repository_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ecs_service_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/apt_rpm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ecs_service_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/archive_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ecs_task_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/async_status_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ecs_tag_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/at_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ecs_taskdefinition_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/atomic_container_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ecs_taskdefinition_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/atomic_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/ecs_taskdefinition_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/atomic_image_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/efs_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/authorized_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/efs_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/awall_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/efs_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_acm_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elasticache_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_api_gateway_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elasticache_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_application_scaling_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elasticache_parameter_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_az_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elasticache_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_batch_compute_environment_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elasticache_snapshot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_batch_job_definition_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elasticache_subnet_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_batch_job_queue_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_application_lb_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_caller_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_application_lb_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_codecommit_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_application_lb_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_config_aggregation_authorization_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_classic_lb_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_config_aggregator_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_classic_lb_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_config_delivery_channel_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_classic_lb_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_config_recorder_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_network_lb_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_config_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_instance_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_direct_connect_connection_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_target_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_direct_connect_gateway_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_target_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_direct_connect_link_aggregation_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_target_group_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_direct_connect_virtual_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_target_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_elasticbeanstalk_app_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_target_group_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_eks_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/elb_target_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_glue_job_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/execute_lambda_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_glue_connection_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_cert_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_inspector_target_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_kms_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_mfa_device_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_kms_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_region_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_cert_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_s3_bucket_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_managed_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_s3_cors_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_mfa_device_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_secret_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_password_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_ses_identity_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_ses_identity_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_policy_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_ses_rule_set_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_role_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_sgw_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_role_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_ssm_parameter_store_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_role_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_waf_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_saml_federation_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_waf_condition_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_server_certificate_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_waf_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_server_certificate_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/aws_waf_web_acl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_acs_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/iam_user_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_aks_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/kinesis_stream_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_aks_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/lambda_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_aksversion_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/lambda_alias_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_appgateway_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/lambda_event_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_applicationsecuritygroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/lambda_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_applicationsecuritygroup_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/lambda_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_appserviceplan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/lambda_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_appserviceplan_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/lightsail_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_autoscale_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/rds_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_autoscale_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/rds_instance_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_availabilityset_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/rds_instance_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_availabilityset_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/rds_instance_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_cdnendpoint_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/rds_param_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_cdnendpoint_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/rds_snapshot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_cdnprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/rds_snapshot_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_cdnprofile_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/rds_snapshot_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_containerinstance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/redshift_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_containerinstance_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/redshift_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_containerregistry_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/redshift_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_containerregistry_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/redshift_subnet_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_cosmosdbaccount_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/rds_subnet_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_deployment_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/redshift_cross_region_snapshots_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlab_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/route53_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlab_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/route53_health_check_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabarmtemplate_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/route53_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabartifact_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/route53_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabartifactsource_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/route53_zone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabartifactsource_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/s3_bucket_notification_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabcustomimage_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/s3_lifecycle_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabcustomimage_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/s3_logging_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabenvironment_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/s3_sync_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabpolicy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/s3_website_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_cosmosdbaccount_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/sns_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_deployment_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/sns_topic_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabschedule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/sqs_queue_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabschedule_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/sts_assume_role_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabvirtualmachine_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/aws/sts_session_token_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabvirtualmachine_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_aks_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabvirtualnetwork_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_aksversion_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabvirtualnetwork_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_aks_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_dnsrecordset_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_applicationsecuritygroup_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_dnsrecordset_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_aksversion_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_dnszone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_applicationsecuritygroup_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_dnszone_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_appserviceplan_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_functionapp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_appserviceplan_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabenvironment_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_automationaccount_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_functionapp_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_automationaccount_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_hdinsightcluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_autoscale_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_devtestlabpolicy_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_autoscale_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_hdinsightcluster_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_availabilityset_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_image_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_availabilityset_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_image_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_cdnendpoint_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_keyvault_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_cdnendpoint_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_keyvaultkey_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_cdnprofile_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_keyvaultsecret_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_cdnprofile_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_loadbalancer_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_containerinstance_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_loadbalancer_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_containerregistry_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_loganalyticsworkspace_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_containerinstance_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_loganalyticsworkspace_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_containerregistry_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_manageddisk_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_cosmosdbaccount_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_manageddisk_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_cosmosdbaccount_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mariadbconfiguration_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_deployment_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mariadbconfiguration_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_deployment_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mariadbdatabase_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlab_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mariadbdatabase_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlab_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mariadbfirewallrule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabarmtemplate_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mariadbfirewallrule_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabarmtemplate_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mariadbserver_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabartifact_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mariadbserver_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabartifact_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mysqlconfiguration_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabcustomimage_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mysqlconfiguration_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabartifactsource_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mysqldatabase_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabartifactsource_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mysqlfirewallrule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabcustomimage_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mysqlfirewallrule_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabenvironment_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mysqlserver_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabenvironment_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mysqlserver_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabpolicy_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_networkinterface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabpolicy_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_networkinterface_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabschedule_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_postgresqlconfiguration_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabschedule_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_postgresqlconfiguration_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabvirtualmachine_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_postgresqldatabase_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabvirtualmachine_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_postgresqldatabase_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabvirtualnetwork_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_postgresqlfirewallrule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_devtestlabvirtualnetwork_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_postgresqlserver_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_dnsrecordset_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_postgresqlfirewallrule_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_dnsrecordset_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_postgresqlserver_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_dnszone_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_publicipaddress_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_dnszone_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_publicipaddress_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_functionapp_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_rediscache_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_functionapp_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_rediscache_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_hdinsightcluster_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_rediscachefirewallrule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_hdinsightcluster_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_mysqldatabase_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_image_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_resource_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_image_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_resourcegroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_loadbalancer_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_resource_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_loadbalancer_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_resourcegroup_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_loganalyticsworkspace_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_roleassignment_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_lock_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_roleassignment_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_lock_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_roledefinition_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_manageddisk_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_roledefinition_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_manageddisk_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_loganalyticsworkspace_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_routetable_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mariadbconfiguration_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_securitygroup_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_managed_disk_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_routetable_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mariadbdatabase_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_servicebus_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_managed_disk_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_servicebus_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mariadbconfiguration_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_servicebusqueue_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_manageddisk_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_servicebussaspolicy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mariadbdatabase_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_servicebustopic_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mariadbserver_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_servicebustopicsubscription_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mariadbfirewallrule_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_sqldatabase_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mariadbfirewallrule_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_sqldatabase_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mariadbserver_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_sqlfirewallrule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mysqldatabase_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_sqlfirewallrule_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mysqlconfiguration_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_sqlserver_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mysqlconfiguration_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_storageaccount_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mysqlfirewallrule_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_sqlserver_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mysqldatabase_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_storageblob_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mysqlfirewallrule_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_storageaccount_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mysqlserver_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_subnet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_mysqlserver_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_subnet_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_networkinterface_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_trafficmanagerendpoint_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_networkinterface_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_trafficmanagerendpoint_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_postgresqlconfiguration_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_trafficmanagerprofile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_postgresqlconfiguration_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_trafficmanagerprofile_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_postgresqldatabase_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualmachine_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_postgresqldatabase_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualmachineextension_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_postgresqlfirewallrule_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualmachineextension_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_postgresqlfirewallrule_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualmachineimage_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_postgresqlserver_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualmachinescaleset_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_postgresqlserver_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualmachinescalesetextension_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_publicipaddress_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualmachinescaleset_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_publicipaddress_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualmachinescalesetextension_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_rediscache_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualmachinescalesetinstance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_resource_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualmachinescalesetinstance_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_resource_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualnetwork_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_rediscache_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualnetwork_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_resourcegroup_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualnetworkgateway_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_roleassignment_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualnetworkpeering_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_resourcegroup_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualnetworkpeering_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_roleassignment_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_webapp_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_roledefinition_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_webapp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_roledefinition_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/azure_rm_webappslot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_routetable_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/beadm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_routetable_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bearychat_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_securitygroup_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bigpanda_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_servicebus_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bitbucket_access_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_securitygroup_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bitbucket_pipeline_key_pair_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_servicebus_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bitbucket_pipeline_known_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_sqldatabase_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bitbucket_pipeline_variable_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_sqlfirewallrule_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bower_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_sqldatabase_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bundler_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_sqlfirewallrule_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/bzr_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_sqlserver_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/campfire_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_sqlserver_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/capabilities_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_storageaccount_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/catapult_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_storageaccount_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/certificate_complete_chain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_subnet_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/circonus_annotation_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_subnet_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cisco_spark_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_trafficmanagerendpoint_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/clc_aa_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_trafficmanagerendpoint_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/clc_alert_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_trafficmanagerprofile_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/clc_blueprint_package_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_trafficmanagerprofile_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/clc_firewall_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachine_extension_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/clc_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachine_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/clc_loadbalancer_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachine_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/clc_modify_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachine_scaleset_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/clc_publicip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachine_scaleset_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/clc_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachineextension_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/clc_server_snapshot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachineextension_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloud_init_data_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachineextension_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudflare_dns_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachineimage_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudformation_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachineimage_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudformation_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachinescaleset_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudformation_stack_set_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachinescaleset_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudfront_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachinescaleset_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudfront_distribution_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachinescalesetextension_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudfront_invalidation_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachinescalesetextension_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudfront_origin_access_identity_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachinescalesetinstance_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudscale_floating_ip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualmachinescalesetinstance_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudscale_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualnetwork_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudscale_server_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualnetwork_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudscale_volume_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualnetworkpeering_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudtrail_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_virtualnetworkpeering_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudwatchevent_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_webapp_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudwatchlogs_log_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/azure/azure_rm_webapp_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cloudwatchlogs_log_group_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cobbler_sync_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_account_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cobbler_system_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_block_storage_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/composer_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_certificate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/consul_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_account_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/consul_acl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_certificate_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/consul_kv_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_certificate_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/consul_session_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_domain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cpanm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_domain_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cpm_plugconfig_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_droplet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cpm_plugcontrol_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_domain_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cpm_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_firewall_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cron_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_floating_ip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cronvar_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_firewall_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/crypttab_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_floating_ip_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_account_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_floating_ip_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_affinitygroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_image_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_image_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_configuration_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_load_balancer_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_disk_offering_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_load_balancer_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_region_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_region_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_firewall_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_size_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_size_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_image_store_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_snapshot_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_instance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_snapshot_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_instance_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_sshkey_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_instance_nic_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_sshkey_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_instance_password_reset_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_sshkey_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_instancegroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_tag_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_ip_address_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_tag_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_iso_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_volume_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_loadbalancer_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_tag_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_instance_nic_secondaryip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_volume_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/acme_account_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_network_acl_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/acme_account_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_physical_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/acme_account_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_network_acl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/acme_certificate_revoke_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_loadbalancer_rule_member_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/acme_certificate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_pod_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/acme_challenge_cert_helper_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_portforward_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/acme_inspect_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_network_offering_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/certificate_complete_chain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_project_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/ecs_certificate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_region_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/ecs_domain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_resourcelimit_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/get_certificate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/luks_device_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_role_permission_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/openssh_cert_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_router_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/openssh_keypair_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_securitygroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_certificate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_securitygroup_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_certificate_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_service_offering_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_csr_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_snapshot_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_csr_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_sshkeypair_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_dhparam_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_staticnat_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_pkcs12_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_privatekey_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_storage_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_privatekey_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_traffic_type_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_signature_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_publickey_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_vlan_ip_range_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_signature_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_vmsnapshot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/x509_certificate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_volume_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/x509_certificate_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_vpc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/x509_crl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_vpc_offering_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/crypto/x509_crl_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_vpn_connection_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/doas_become.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_vpn_customer_gateway_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/dzdo_become.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_vpn_gateway_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/machinectl_become.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_zone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ksu_become.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cs_zone_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pbrun_become.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cyberark_authentication_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pfexec_become.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/cyberark_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pmrun_become.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/data_pipeline_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sesu_become.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/datadog_monitor_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/memcached_cache.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dconf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pickle_cache.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/debconf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/redis_cache.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/deploy_helper_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/yaml_cache.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/actionable_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_account_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/cgroup_memory_recap_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_block_storage_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/context_demo_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_certificate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/counter_enabled_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_certificate_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/dense_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/diy_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_domain_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/full_skip_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_firewall_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hipchat_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_floating_ip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/jabber_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_floating_ip_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/log_plays_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_image_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/logdna_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_load_balancer_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/logentries_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_region_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/logstash_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_size_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nrdp_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_snapshot_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/mail_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_sshkey_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/null_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/datadog_event_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/say_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_sshkey_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/osx_say_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_tag_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/selective_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_tag_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/splunk_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/digital_ocean_volume_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/slack_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dimensiondata_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/stderr_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dimensiondata_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sumologic_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/django_manage_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/syslog_json_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dnsimple_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/unixy_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dnsmadeeasy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/yaml_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/chroot_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_container_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_host_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/funcd_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_image_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/iocage_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_login_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/jail_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/lxc_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_network_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/lxd_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_node_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oc_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_node_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/qubes_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_prune_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/saltstack_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_secret_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/zone_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_stack_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/cobbler_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_swarm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_machine_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_swarm_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_swarm_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_swarm_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gitlab_runners_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_swarm_service_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/kubevirt_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_volume_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nmap_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/docker_volume_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/online_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dpkg_selections_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/linode_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dynamodb_table_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/dynamodb_ttl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/virtualbox_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/easy_install_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/cartesian_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/chef_databag_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_ami_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/cyberarkpassword_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_ami_copy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/consul_kv_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_ami_find_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/dig_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_asg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/credstash_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_asg_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/dnstxt_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_asg_lifecycle_hook_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/dsv_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_customer_gateway_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/etcd_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_customer_gateway_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/etcd3_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_eip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/filetree_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_eip_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/flattened_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_elb_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hashi_vault_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_elb_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gcp_storage_file_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_elb_lb_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hiera_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_eni_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/keyring_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_eni_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/lastpass_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/lmdb_kv_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_group_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/manifold_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_instance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_instance_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_next_ip_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_next_network_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_launch_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/onepassword_raw_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_lc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/onepassword_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_lc_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/passwordstore_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_lc_find_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/shelvefile_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_metadata_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/redis_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_metric_alarm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/tss_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_placement_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/aerospike_migrations_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_placement_group_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/airbrake_deployment_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_scaling_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/aix_devices_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_snapshot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/aix_filesystem_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_snapshot_copy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/aix_inittab_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_snapshot_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/aix_lvg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_tag_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/aix_lvol_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_transit_gateway_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ali_instance_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vol_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ali_instance_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vol_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ali_instance_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_dhcp_option_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/alternatives_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_egress_igw_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/apache2_mod_proxy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_endpoint_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/apache2_module_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_endpoint_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/apk_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_igw_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/apt_repo_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_nacl_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/apt_rpm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_nat_gateway_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/archive_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_net_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/atomic_container_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_peer_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/atomic_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_peering_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/atomic_image_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_route_table_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/awall_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_subnet_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/bearychat_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_vgw_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/beadm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_vgw_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/bigpanda_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_vpn_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/bitbucket_access_key_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_vpc_vpn_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/bitbucket_pipeline_key_pair_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ec2_win_password_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/bitbucket_pipeline_known_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ecs_attribute_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/bitbucket_pipeline_variable_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ecs_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/bower_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ecs_ecr_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/bundler_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ecs_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/bzr_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ecs_service_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/campfire_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ecs_task_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/capabilities_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ecs_taskdefinition_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/catapult_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/efs_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/circonus_annotation_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ecs_taskdefinition_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/cisco_spark_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/efs_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/cisco_webex_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ejabberd_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/clc_alert_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elasticache_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/clc_aa_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elasticache_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/clc_blueprint_package_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elasticache_parameter_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/clc_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elasticache_snapshot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/clc_firewall_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elasticsearch_plugin_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/clc_loadbalancer_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elasticache_subnet_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/clc_modify_server_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elb_application_lb_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/clc_publicip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elb_application_lb_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/clc_server_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elb_classic_lb_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/clc_server_snapshot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elb_classic_lb_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/cloud_init_data_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elb_instance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/cloudflare_dns_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elb_network_lb_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/cobbler_sync_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elb_target_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/cobbler_system_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elb_target_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/consul_acl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elb_target_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/composer_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/elb_target_group_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/consul_kv_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/emc_vnx_sg_member_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/consul_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/etcd3_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/cpanm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/execute_lambda_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/cronvar_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/exo_dns_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/crypttab_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/exo_dns_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/consul_session_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/expect_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/datadog_event_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/facter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/datadog_monitor_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/fail_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/dconf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/filesystem_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/deploy_helper_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/find_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/dimensiondata_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/firewalld_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/dimensiondata_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/flatpak_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/django_manage_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/flatpak_remote_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/dnsimple_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/flowdock_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/dnsmadeeasy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/foreman_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gather_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_compose_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gc_storage_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_container_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcdns_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_container_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcdns_zone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_image_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gce_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_host_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gce_eip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_image_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gce_img_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_image_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gce_instance_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_login_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gce_labels_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_network_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gce_lb_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_node_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gce_mig_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_node_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gce_net_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_secret_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gce_pd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gce_snapshot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_stack_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gce_tag_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_stack_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gconftool2_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_prune_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_backend_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_stack_task_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_bigquery_dataset_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_service_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_bigquery_dataset_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_swarm_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_bigquery_table_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_swarm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_bigquery_table_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_swarm_service_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_cloudbuild_trigger_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_swarm_service_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_cloudbuild_trigger_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_volume_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_address_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/docker_volume_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_address_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/dpkg_divert_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_backend_bucket_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/easy_install_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_backend_bucket_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/elasticsearch_plugin_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_backend_service_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ejabberd_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_disk_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/emc_vnx_sg_member_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_disk_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/etcd3_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_firewall_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/facter_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_firewall_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/filesystem_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_forwarding_rule_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/flatpak_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_global_address_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/flatpak_remote_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_global_address_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/flowdock_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_global_forwarding_rule_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/foreman_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_http_health_check_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gc_storage_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_health_check_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gcdns_record_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_https_health_check_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gcdns_zone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_image_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gce_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_image_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gce_eip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_instance_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gce_img_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_instance_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gce_instance_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_instance_group_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gce_labels_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_instance_group_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gce_lb_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_instance_group_manager_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gce_mig_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_instance_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gce_net_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_instance_template_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gce_pd_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_interconnect_attachment_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gce_snapshot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_interconnect_attachment_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gce_tag_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gconftool2_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_network_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gcp_backend_service_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_region_disk_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gcp_forwarding_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_region_disk_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gcp_healthcheck_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_route_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gcp_target_proxy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gcp_url_map_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_router_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gcpubsub_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_router_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gcpubsub_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_ssl_certificate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gcpubsub_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_ssl_certificate_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gcspanner_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_ssl_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gem_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_ssl_policy_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/git_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_subnetwork_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/github_hooks_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_subnetwork_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/github_deploy_key_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_target_http_proxy_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/github_issue_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_target_https_proxy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/github_key_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_target_https_proxy_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/github_release_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_target_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/github_webhook_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_target_pool_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/github_webhook_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_target_ssl_proxy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gitlab_deploy_key_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_target_ssl_proxy_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gitlab_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_target_tcp_proxy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gitlab_hook_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_target_tcp_proxy_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gitlab_project_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_target_vpn_gateway_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gitlab_project_variable_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_target_vpn_gateway_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gitlab_runner_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_url_map_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gitlab_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_vpn_tunnel_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gluster_peer_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_compute_vpn_tunnel_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gluster_heal_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_container_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gluster_volume_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_container_cluster_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/grove_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_container_node_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/gunicorn_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_dns_managed_zone_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/haproxy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_container_node_pool_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/helm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_dns_resource_record_set_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/heroku_collaborator_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_forwarding_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hetzner_failover_ip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_healthcheck_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hetzner_failover_ip_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_iam_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hetzner_firewall_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_iam_role_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hetzner_firewall_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_iam_service_account_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_iam_service_account_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hipchat_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_iam_service_account_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/homebrew_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_pubsub_subscription_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/homebrew_tap_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_pubsub_subscription_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/homebrew_cask_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_pubsub_topic_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/honeybadger_deployment_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_pubsub_topic_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hpilo_boot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_redis_instance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hpilo_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_redis_instance_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hpilo_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_resourcemanager_project_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hponcfg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_resourcemanager_project_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/htpasswd_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_sourcerepo_repository_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hwc_ecs_instance_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_sourcerepo_repository_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hwc_evs_disk_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_spanner_database_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hwc_network_vpc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_spanner_instance_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hwc_smn_topic_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_sql_database_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hwc_vpc_eip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_sql_database_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hwc_vpc_peering_connect_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_sql_instance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hwc_vpc_port_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_sql_instance_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hwc_vpc_private_ip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_sql_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hwc_vpc_route_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_sql_user_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hwc_vpc_security_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_storage_bucket_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hwc_vpc_security_group_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_storage_bucket_access_control_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/hwc_vpc_subnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_storage_object_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ibm_sa_domain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_target_proxy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ibm_sa_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcp_url_map_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ibm_sa_pool_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcpubsub_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ibm_sa_vol_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcpubsub_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ibm_sa_host_ports_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gcspanner_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ibm_sa_vol_map_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gem_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/icinga2_feature_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/get_certificate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/icinga2_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/get_url_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/idrac_firmware_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/getent_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/idrac_redfish_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/git_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/idrac_redfish_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/git_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/idrac_redfish_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/github_deploy_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/idrac_redfish_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/github_hooks_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/imc_rest_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/github_issue_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/idrac_server_config_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/github_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/imgadm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/github_release_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/infinity_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gitlab_deploy_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/influxdb_database_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gitlab_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/influxdb_query_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gitlab_hook_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/influxdb_retention_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gitlab_project_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/influxdb_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gitlab_runner_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/influxdb_write_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gitlab_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/installp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gluster_heal_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ini_file_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gluster_peer_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/interfaces_file_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gluster_volume_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ip_netns_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/grafana_dashboard_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_dnsrecord_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/grafana_datasource_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_dnszone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/grove_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_hbacrule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/gunicorn_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hall_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_hostgroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/haproxy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hcloud_datacenter_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_sudocmd_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hcloud_floating_ip_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_role_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hcloud_image_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_service_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hcloud_location_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_sudocmdgroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hcloud_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_subca_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hcloud_server_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_sudorule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hcloud_server_type_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hcloud_ssh_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipify_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hcloud_ssh_key_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipa_vault_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hcloud_volume_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipinfoio_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hcloud_volume_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipmi_boot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/helm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipmi_power_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/heroku_collaborator_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/iptables_state_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ipwcli_dns_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/grafana_plugin_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/irc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hipchat_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/iso_create_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/homebrew_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/iso_extract_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/homebrew_cask_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/jabber_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/homebrew_tap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/java_cert_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/honeybadger_deployment_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/java_keystore_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hostname_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/jboss_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hpilo_boot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/jenkins_job_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hpilo_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/jenkins_job_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hponcfg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/jenkins_job_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/htpasswd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/jenkins_script_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hwc_network_vpc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/jenkins_plugin_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/hwc_smn_topic_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/jira_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iam_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/katello_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iam_cert_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/kernel_blacklist_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iam_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/keycloak_client_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iam_managed_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/keycloak_clienttemplate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iam_mfa_device_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/keycloak_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iam_password_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/kibana_plugin_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iam_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/kubevirt_cdi_upload_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iam_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/kubevirt_preset_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iam_role_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/kubevirt_pvc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iam_server_certificate_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/kubevirt_rs_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iam_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/kubevirt_vm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ibm_sa_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/kubevirt_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ibm_sa_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/launchd_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ibm_sa_host_ports_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/layman_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ibm_sa_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/lbu_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ibm_sa_vol_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ldap_attr_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ibm_sa_vol_map_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ldap_attrs_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/icinga2_feature_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ldap_entry_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/icinga2_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ldap_passwd_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/idrac_firmware_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ldap_search_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/idrac_redfish_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/librato_annotation_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/idrac_redfish_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/linode_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/idrac_redfish_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/linode_v4_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/idrac_server_config_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/listen_ports_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/imgadm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/lldp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/imc_rest_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/locale_gen_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/import_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/logentries_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/import_playbook_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/logentries_msg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/import_tasks_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/logstash_plugin_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/include_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/lvg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/include_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/lxc_container_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/include_tasks_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/lvol_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/infini_export_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/lxca_cmms_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/infini_export_client_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/lxca_nodes_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/infini_fs_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/lxd_container_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/infini_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/lxd_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/infini_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/macports_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/infini_vol_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/mail_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/infinity_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/make_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/influxdb_database_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/manageiq_alert_profiles_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/influxdb_query_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/manageiq_alerts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/influxdb_retention_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/manageiq_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/influxdb_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/manageiq_provider_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/influxdb_write_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/manageiq_policies_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ini_file_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/manageiq_tags_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/installp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/manageiq_tenant_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/interfaces_file_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/manageiq_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/intersight_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/mas_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/intersight_rest_api_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/matrix_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ip_netns_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/mattermost_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/memset_dns_reload_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_dnsrecord_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/maven_artifact_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_dnszone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/memset_memstore_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/memset_memstore_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_hbacrule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/memset_server_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/memset_server_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_hostgroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/memset_zone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/memset_zone_domain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/memset_zone_record_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_subca_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/mksysb_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_sudocmd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/modprobe_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_sudocmdgroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/mqtt_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_sudorule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/monit_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/mssql_db_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipa_vault_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/na_cdot_aggregate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipify_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/na_cdot_license_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipinfoio_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/na_cdot_lun_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipmi_boot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/na_cdot_qtree_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ipmi_power_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/na_cdot_user_role_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iptables_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/na_cdot_svm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/irc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/na_cdot_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/iso_extract_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/na_cdot_volume_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/jabber_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/na_ontap_gather_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/java_cert_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nagios_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/java_keystore_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/netcup_dns_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/jboss_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/newrelic_deployment_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/jenkins_job_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nexmo_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/jenkins_job_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nginx_status_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/jenkins_plugin_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nginx_status_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/jenkins_script_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nictagadm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/jira_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_a_record_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/k8s_auth_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_cname_record_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/k8s_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_aaaa_record_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/k8s_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_dns_view_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/katello_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_fixed_address_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/kernel_blacklist_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_member_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/keycloak_client_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_host_record_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/keycloak_clienttemplate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_mx_record_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/keycloak_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_naptr_record_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/kibana_plugin_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/kinesis_stream_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_network_view_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/known_hosts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_nsgroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/kubernetes_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_srv_record_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/kubevirt_cdi_upload_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_ptr_record_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/kubevirt_preset_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_txt_record_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/kubevirt_pvc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nios_zone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/kubevirt_rs_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/npm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/kubevirt_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oci_vcn_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lambda_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/office_365_connector_card_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/kubevirt_vm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ohai_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lambda_alias_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nmcli_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lambda_event_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nsupdate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lambda_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ome_device_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lambda_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/nosh_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/layman_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/one_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ldap_attr_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/odbc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ldap_passwd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/one_image_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/librato_annotation_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/omapi_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lightsail_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/one_image_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/linode_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/one_image_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/linode_v4_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/one_service_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lldp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/one_vm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/locale_gen_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneandone_firewall_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/logentries_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneandone_private_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/logentries_msg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneandone_load_balancer_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/logicmonitor_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneandone_monitoring_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/logicmonitor_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneandone_public_ip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/logstash_plugin_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneandone_server_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/luks_device_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/onepassword_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lvg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/onepassword_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lvol_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_datacenter_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lxca_cmms_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_datacenter_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lxc_container_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_enclosure_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lxca_nodes_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_enclosure_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lxd_container_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_ethernet_network_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/lxd_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_ethernet_network_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/macports_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_ethernet_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mail_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_fc_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/make_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_fc_network_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/manageiq_alert_profiles_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_fc_network_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/manageiq_alerts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_fcoe_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/manageiq_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_fcoe_network_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/manageiq_policies_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_fcoe_network_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/manageiq_tags_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_logical_interconnect_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/manageiq_provider_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_logical_interconnect_group_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/manageiq_tenant_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_logical_interconnect_group_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ldap_entry_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_network_set_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/manageiq_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_network_set_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/matrix_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_san_manager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mattermost_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_network_set_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/maven_artifact_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_san_manager_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/memset_dns_reload_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/oneview_san_manager_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/memset_memstore_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/online_server_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/memset_zone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/online_server_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/memset_server_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/online_user_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/memset_zone_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/online_user_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/memset_zone_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/open_iscsi_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/meta_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/openbsd_pkg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mksysb_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/opendj_backendprop_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/modprobe_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/openwrt_init_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mongodb_parameter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/opkg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mongodb_replicaset_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/osx_defaults_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mongodb_shard_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovh_ip_failover_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mongodb_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovh_ip_loadbalancing_backend_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/monit_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovh_monthly_billing_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mount_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mqtt_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_affinity_label_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mssql_db_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_api_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mysql_db_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_cluster_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mysql_replication_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_datacenter_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mysql_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_disk_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/mysql_variables_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_event_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_cdot_aggregate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_host_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_cdot_license_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_external_provider_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_cdot_lun_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_group_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_cdot_qtree_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_nic_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_cdot_svm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_permission_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_cdot_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_host_storage_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_cdot_user_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_network_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_cdot_volume_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_snapshot_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_admin_users_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_quota_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_backup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_scheduling_policy_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_storage_domain_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_cluster_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_tag_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_cluster_pair_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_storage_vm_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_cluster_snmp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_storage_template_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_drive_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_template_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_initiators_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_user_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_ldap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_vm_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_network_interfaces_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ovirt_vmpool_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_node_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pacemaker_cluster_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_snapshot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/packet_device_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_snapshot_restore_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/packet_ip_subnet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/packet_project_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_volume_clone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/packet_sshkey_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_elementsw_volume_pair_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/packet_volume_attachment_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_autosupport_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/packet_volume_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_broadcast_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pacman_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_broadcast_domain_ports_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pagerduty_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_cg_snapshot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pagerduty_alert_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_cifs_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pam_limits_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_cifs_acl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pamd_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_cifs_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pear_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_cluster_ha_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pids_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_cluster_peer_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/parted_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pingdom_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_dns_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pip_package_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pkg5_publisher_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_disks_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pkgin_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_export_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pkgng_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_export_policy_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/portinstall_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_fcp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_copy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_firewall_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pkg5_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_flexcache_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_ext_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_gather_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_idx_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_igroup_initiator_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_igroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_db_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pkgutil_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_iscsi_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/portage_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_job_schedule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_membership_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_lun_copy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_lang_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_lun_map_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_owner_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_motd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_pg_hba_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_net_ifgrp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_ping_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_net_port_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_publication_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_net_routes_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_query_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_net_subnet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_privs_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_net_vlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_schema_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_nfs_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_sequence_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_node_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_set_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_ntp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_slot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_nvme_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_subscription_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_nvme_namespace_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_table_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_nvme_subsystem_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_user_obj_stat_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_portset_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_tablespace_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_qos_policy_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_quotas_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/profitbricks_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_security_key_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/profitbricks_datacenter_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_service_processor_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/profitbricks_nic_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_snapmirror_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/profitbricks_volume_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_snapshot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/profitbricks_volume_attachments_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_snapshot_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_kvm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_snmp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_software_update_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_svm_options_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pubnub_blocks_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_ucadapter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pulp_repo_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_unix_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/puppet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_unix_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/purefa_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_volume_clone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/purefb_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_vscan_on_access_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pushbullet_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_vscan_on_demand_task_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/pushover_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_vscan_scanner_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/python_requirements_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/na_ontap_vserver_peer_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/python_requirements_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nagios_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_alerts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_cbs_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_amg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_cbs_attachments_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_amg_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_cdb_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_amg_sync_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_cdb_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_asup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_clb_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_auditlog_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_clb_nodes_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_auth_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_cdb_database_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_clb_ssl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_flashcache_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_dns_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_global_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_dns_record_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_hostgroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_files_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_iscsi_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_files_objects_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_iscsi_target_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_mon_alarm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_lun_mapping_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_identity_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_ldap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_keypair_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_mgmt_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_meta_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_snapshot_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_mon_check_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_snapshot_images_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_mon_notification_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_snapshot_volume_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_mon_notification_plan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_storage_system_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_mon_entity_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_storagepool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_syslog_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/redfish_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_volume_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/redfish_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netapp_e_volume_copy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_queue_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netbox_device_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_scaling_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netbox_interface_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rax_scaling_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netbox_ip_address_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/read_csv_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netbox_prefix_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/redis_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netcup_dns_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/redfish_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/netbox_site_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/redfish_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/newrelic_deployment_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/redhat_subscription_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nexmo_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/redis_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nginx_status_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rhevm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nictagadm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rhn_channel_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_a_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rhn_register_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_aaaa_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rhsm_repository_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_cname_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rhsm_release_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_dns_view_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/riak_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_fixed_address_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rocketchat_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_host_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rollbar_deployment_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_member_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/runit_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_mx_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rundeck_acl_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_naptr_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/rundeck_project_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_network_view_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/say_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_nsgroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_image_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_ptr_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_compute_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_srv_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_image_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_txt_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_ip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nios_zone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_ip_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nmcli_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_ip_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nosh_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_lb_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/npm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_organization_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/nsupdate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_organization_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_security_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oci_vcn_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_security_group_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/office_365_connector_card_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_security_group_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ohai_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_server_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/omapi_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_security_group_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/one_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_server_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/one_image_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_snapshot_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/one_image_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_snapshot_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/one_vm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_sshkey_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneandone_firewall_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_user_data_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneandone_load_balancer_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_volume_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneandone_monitoring_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_volume_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneandone_private_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/scaleway_volume_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneandone_public_ip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sefcontext_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneandone_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/selinux_permissive_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/onepassword_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/selogin_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_datacenter_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sendgrid_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_enclosure_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sensu_check_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_ethernet_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sensu_client_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_ethernet_network_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sensu_silence_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_fc_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sensu_subscription_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_fc_network_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sensu_handler_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_fcoe_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/seport_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_fcoe_network_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/serverless_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_logical_interconnect_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sf_account_manager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_logical_interconnect_group_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sf_check_connections_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_network_set_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sf_snapshot_schedule_manager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/one_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sf_volume_access_group_manager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_network_set_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/shutdown_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_san_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sf_volume_manager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/oneview_san_manager_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sl_vm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/online_server_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/slack_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/online_user_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/slackpkg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/open_iscsi_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/smartos_image_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openbsd_pkg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/smartos_image_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/opendj_backendprop_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/snap_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openssh_cert_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/snmp_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openssh_keypair_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/solaris_zone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openssl_certificate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sorcery_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openssl_certificate_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/spectrum_device_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openssl_csr_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/spotinst_aws_elastigroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openssl_csr_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ss_3par_cpg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openssl_pkcs12_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/stacki_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openssl_dhparam_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/stackdriver_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openssl_privatekey_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/statusio_maintenance_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openssl_privatekey_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/supervisorctl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openssl_publickey_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/svc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/openwrt_init_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/svr4pkg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/opkg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/swdepot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_auth_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/swupd_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_client_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/syslogger_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_coe_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/syspatch_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_coe_cluster_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/sysupgrade_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_flavor_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/taiga_issue_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_floating_ip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/terraform_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/telegram_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_image_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/timezone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_image_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/twilio_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_ironic_inspect_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/typetalk_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_ironic_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/udm_dns_record_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_keypair_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/udm_dns_zone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_keystone_domain_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/udm_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_keystone_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/udm_share_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_keystone_endpoint_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/udm_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_loadbalancer_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/ufw_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_keystone_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/uptimerobot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_keystone_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/urpmi_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_listener_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/utm_aaa_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_member_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/utm_aaa_group_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/utm_ca_host_key_cert_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_networks_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/utm_ca_host_key_cert_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_nova_host_aggregate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/utm_dns_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_nova_flavor_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/utm_network_interface_address_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_object_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/utm_network_interface_address_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/utm_proxy_auth_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_port_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/utm_proxy_exception_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_port_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/utm_proxy_frontend_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_project_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/utm_proxy_frontend_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_project_access_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/utm_proxy_location_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_project_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/utm_proxy_location_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_quota_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/vdo_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_recordset_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/vertica_configuration_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_router_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/vertica_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_security_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/vertica_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_security_group_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/vertica_role_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/vertica_schema_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_server_action_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/vertica_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_server_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/vexata_eg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_server_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/vexata_volume_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_server_metadata_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/wakeonlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_server_volume_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/vmadm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_stack_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/webfaction_app_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_subnet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/webfaction_domain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_subnets_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/webfaction_db_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/webfaction_mailbox_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_user_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/webfaction_site_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_user_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/xattr_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_user_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/xbps_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_volume_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/xenserver_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_volume_snapshot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/xenserver_guest_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/os_zone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/xenserver_guest_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/osx_defaults_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/xenserver_guest_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovh_ip_failover_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/xenserver_guest_powerstate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovh_ip_loadbalancing_backend_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/xfconf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/xfs_quota_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_affinity_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/yarn_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_affinity_label_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/xml_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_affinity_label_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/zfs_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_api_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/zfs_delegate_admin_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_auth_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/zfs_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/znode_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_cluster_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/zpool_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_datacenter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/zypper_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_datacenter_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/general/zypper_repository_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_disk_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_annotations_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_disk_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_dashboard_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_event_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_dashboard_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_event_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_datasource_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_external_provider_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_folder_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_external_provider_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_plugin_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_team_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_group_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/kubectl_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_host_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/k8s_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_host_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/k8s_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_host_pm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/helm_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_host_storage_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/helm_plugin_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_instance_type_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/k8s_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_mac_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/openshift_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_network_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/helm_plugin_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/helm_repository_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_nic_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/helm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_nic_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/k8s_auth_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_permission_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/k8s_exec_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_permission_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/k8s_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_quota_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/k8s_log_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_quota_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/k8s_scale_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/kubernetes/k8s_service_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_scheduling_policy_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_cache.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_snapshot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_snapshot_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_index_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_storage_connection_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_balancer_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_storage_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_storage_domain_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_maintenance_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_storage_template_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_oplog_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_storage_vm_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_parameter_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_tag_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_replicaset_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_tag_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_shard_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_status_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_template_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_shutdown_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/libvirt/libvirt_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_user_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/libvirt/virt_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_vm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_vm_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mongodb/mongodb_stepdown_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_vmpool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/libvirt/libvirt_lxc_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_vmpool_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/libvirt/libvirt_qemu_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ovirt_vnic_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/libvirt/virt_net_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pacemaker_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/package_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_query_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/package_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/libvirt/virt_pool_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/packet_sshkey_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/packet_device_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_db_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pacman_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_variables_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pagerduty_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_replication_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pagerduty_alert_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/apconos_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pam_limits_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/aruba_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pamd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/parted_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/aireos_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/patch_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pause_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/edgeos_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pear_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/edgeswitch_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pids_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/enos_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ping_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/eric_eccli_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pingdom_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/exos_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pip_package_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ironware_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pkg5_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netvisor_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pkg5_publisher_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/nos_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pkgin_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/routeros_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pkgng_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/slxos_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pkgutil_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/voss_cliconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/podman_image_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/exos_httpapi.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/podman_image_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fortianalyzer_httpapi.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/portage_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fortimanager_httpapi.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/portinstall_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ftd_httpapi.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_db_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_ext_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/a10_server_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_idx_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/a10_server_axapi3_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/a10_service_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_membership_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/aireos_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_lang_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/a10_virtual_server_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_owner_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/aireos_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_pg_hba_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/apconos_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_ping_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/aruba_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_privs_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/aruba_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_query_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_actiongroupconfig_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_schema_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_alertconfig_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_set_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_alertemailconfig_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_slot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_alertscriptconfig_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_table_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_alertsyslogconfig_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_tablespace_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_api_version_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/postgresql_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_api_session_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/profitbricks_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_analyticsprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/profitbricks_datacenter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_applicationpersistenceprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/profitbricks_nic_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_applicationprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/profitbricks_volume_attachments_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_authprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/proxmox_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_autoscalelaunchconfig_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/proxmox_kvm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_backupconfiguration_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/proxysql_backend_servers_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_backup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/proxmox_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_cloudproperties_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/proxysql_global_variables_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_certificatemanagementprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/proxysql_manage_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_cluster_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/proxysql_mysql_users_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_cloudconnectoruser_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/proxysql_query_rules_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_cloud_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/proxysql_replication_hostgroups_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_clusterclouddetails_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/proxysql_scheduler_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_customipamdnsprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/psexec_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_dnspolicy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pubnub_blocks_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_errorpagebody_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pulp_repo_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_controllerproperties_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/puppet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_errorpageprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_dns_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_gslbgeodbprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_ds_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_gslb_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_dsrole_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_gslbservice_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/profitbricks_volume_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_gslbservice_patch_member_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_hardwaresecuritymodulegroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_hg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_healthmonitor_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_ipaddrgroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_ntp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_httppolicyset_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_offload_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_ipamdnsproviderprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_pg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_microservicegroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_pgsnap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_l4policyset_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_ra_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_snap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_networkprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_networksecuritypolicy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefb_bucket_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_pkiprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefa_volume_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_pool_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefb_ds_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_poolgroupdeploymentpolicy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefb_dsrole_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_poolgroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefb_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_role_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefb_fs_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_prioritylabels_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefb_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_scheduler_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefb_s3acc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_seproperties_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefb_s3user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_serverautoscalepolicy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefb_snap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_serviceengine_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/purefb_subnet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_serviceenginegroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pushbullet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_snmptrapprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/pushover_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_sslkeyandcertificate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/python_requirements_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_stringgroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rabbitmq_binding_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_sslprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rabbitmq_exchange_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_systemconfiguration_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rabbitmq_global_parameter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_tenant_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rabbitmq_parameter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_trafficcloneprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rabbitmq_plugin_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rabbitmq_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_useraccount_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rabbitmq_publish_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_useraccountprofile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rabbitmq_queue_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_virtualservice_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rabbitmq_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_vrfcontext_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rabbitmq_vhost_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_vsdatascriptset_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rabbitmq_vhost_limits_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_vsvip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/avi_webhook_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_cbs_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/bcf_switch_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_cbs_attachments_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/bigmon_chain_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_cdb_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/bigmon_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_cdb_database_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_aaa_server_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_clb_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_aaa_server_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_clb_nodes_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_acl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_clb_ssl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_acl_advance_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_cdb_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_acl_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_files_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_bfd_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_files_objects_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_bfd_session_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_keypair_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_bfd_view_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_dns_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_bgp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_bgp_neighbor_af_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_dns_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_bgp_af_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_identity_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_bgp_neighbor_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_meta_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_mon_alarm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_dldp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_mon_check_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_dldp_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_mon_entity_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_mon_notification_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_eth_trunk_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_mon_notification_plan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_evpn_bd_vni_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_evpn_bgp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_queue_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_evpn_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_scaling_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_evpn_bgp_rr_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rax_scaling_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rds_instance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_file_copy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rds_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_info_center_debug_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rds_instance_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_info_center_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rds_param_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_info_center_log_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rds_snapshot_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_info_center_trap_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rds_subnet_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/read_csv_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_is_is_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/reboot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_lacp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/redfish_command_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_interface_ospf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/redfish_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_ip_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/redfish_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_is_is_instance_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/redhat_subscription_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_lldp_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/redis_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_is_is_view_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/redshift_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_link_status_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/redshift_cross_region_snapshots_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_lldp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/redshift_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_mdn_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/redshift_subnet_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_mlag_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rhevm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_mlag_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rhn_channel_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_mtu_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rhn_register_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_multicast_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rhsm_release_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_multicast_igmp_enable_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rhsm_repository_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_netconf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/riak_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_netstream_aging_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rocketchat_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_netstream_export_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rollbar_deployment_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_netstream_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/route53_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_netstream_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/route53_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_ntp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/route53_health_check_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_ntp_auth_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/route53_zone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_ospf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rpm_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_ospf_vrf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rundeck_project_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_reboot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/runit_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_rollback_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/s3_logging_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_sflow_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/s3_lifecycle_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_snmp_community_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/s3_sync_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_snmp_contact_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/s3_website_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_snmp_location_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_image_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_snmp_target_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_ip_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_snmp_traps_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_ip_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_snmp_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_lb_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_startup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_organization_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_static_route_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_security_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_static_route_bfd_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_security_group_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_stp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_security_group_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_switchport_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_server_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_snapshot_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_vrf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_user_data_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_vrf_af_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/scaleway_volume_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_vrf_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/seboolean_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_vrrp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/rundeck_acl_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_vxlan_arp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sefcontext_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_vxlan_gateway_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/selinux_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_vxlan_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/selinux_permissive_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_vxlan_vap_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/selogin_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_vxlan_tunnel_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sendgrid_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_backup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sensu_check_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_banner_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sensu_client_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_bgp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sensu_handler_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sensu_silence_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_conditional_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sensu_subscription_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_conditional_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/seport_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/serverless_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_factory_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/service_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_image_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/set_stats_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_l3_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sf_account_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sf_check_connections_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_l2_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sf_snapshot_schedule_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_linkagg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sf_volume_access_group_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_lldp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sf_volume_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_logging_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sl_vm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_reload_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/slack_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_rollback_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/slackpkg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_save_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/slurp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_showrun_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/smartos_image_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_static_route_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/snap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_system_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/snmp_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/snow_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sns_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_vlag_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sorcery_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_vrf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sns_topic_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cp_publish_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/solaris_zone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cnos_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/spectrum_device_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/cv_server_provision_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sqs_queue_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/dladm_etherstub_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/spotinst_aws_elastigroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/dladm_linkprop_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ss_3par_cpg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/dladm_iptun_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/stackdriver_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/dladm_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/stacki_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/dladm_vnic_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/statusio_maintenance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/edgeos_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sts_assume_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/edgeos_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sts_session_token_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/edgeos_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/subversion_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/edgeswitch_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/supervisorctl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/edgeswitch_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/svc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/enos_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/svr4pkg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/enos_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/swdepot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/eric_eccli_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/swupd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/enos_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/synchronize_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/exos_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sysctl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/exos_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/syslogger_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/exos_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/systemd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/exos_l2_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/sysvinit_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/exos_lldp_global_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/taiga_issue_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/exos_lldp_interfaces_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/telegram_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/exos_vlans_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/telnet_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/flowadm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tempfile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/faz_device_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/terraform_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_device_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/timezone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_device_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_credential_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_device_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_credential_type_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_fwobj_address_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_device_provision_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_fwobj_ippool_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_inventory_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_fwobj_ippool6_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_inventory_source_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_fwobj_service_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_job_cancel_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_fwobj_vip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_job_launch_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_fwpol_ipv4_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_job_list_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_ha_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_job_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_fwpol_package_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_job_wait_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_provisioning_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_label_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_query_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_organization_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_script_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_notification_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_secprof_appctrl_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_receive_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_secprof_dns_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_send_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_secprof_av_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_secprof_profile_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_team_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_secprof_ips_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_workflow_launch_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_secprof_spam_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_secprof_proxy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_workflow_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_secprof_ssl_ssh_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/twilio_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_secprof_voip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_secprof_waf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/typetalk_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_secprof_wanopt_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/tower_project_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/fmgr_secprof_web_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_disk_group_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ftd_configuration_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_dns_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ftd_file_download_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_ip_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ftd_file_upload_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_lan_connectivity_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ftd_install_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_mac_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/iap_start_workflow_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_managed_objects_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/iap_token_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_ntp_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_banner_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_org_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_san_connectivity_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_copy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_service_profile_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_storage_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_timezone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_l3_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_vhba_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_vlans_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_linkagg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_vnic_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_lldp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_vsans_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_logging_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_wwn_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_ping_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/udm_dns_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_system_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/udm_dns_zone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_static_route_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/udm_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/udm_share_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ig_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ufw_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/icx_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/udm_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ig_unit_information_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/uptimerobot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ipadm_addr_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/uri_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ipadm_if_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/urpmi_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ipadm_addrprop_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/utm_aaa_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ipadm_ifprop_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/utm_aaa_group_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ipadm_prop_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/utm_ca_host_key_cert_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ironware_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/utm_ca_host_key_cert_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ironware_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/utm_dns_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ironware_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/ucs_uuid_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/nclu_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/utm_network_interface_address_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netact_cm_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/utm_network_interface_address_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_cs_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/utm_proxy_exception_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_cs_action_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/utm_proxy_auth_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_cs_vserver_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/utm_proxy_frontend_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_gslb_service_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/utm_proxy_frontend_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_gslb_site_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/utm_proxy_location_info_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_lb_monitor_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/utm_proxy_location_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_gslb_vserver_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vca_fw_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_lb_vserver_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vca_nat_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_save_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vca_vapp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_nitro_request_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vcenter_extension_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_service_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vcenter_extension_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_server_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vcenter_folder_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_servicegroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vcenter_license_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/nos_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vdo_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/netscaler_ssl_certkey_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vertica_configuration_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/nos_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vertica_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/nos_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vertica_role_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/nso_action_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vertica_schema_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/nso_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vertica_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/nso_query_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vexata_volume_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/nso_show_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/virt_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/nso_verify_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/virt_net_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/opx_cps_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/virt_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/nuage_vspk_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmadm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ordnance_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_about_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ordnance_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_category_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_admin_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_category_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_admpwd_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_cfg_backup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_cert_gen_ssh_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_check_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_cluster_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_commit_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_datastore_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_dag_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_datastore_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_dag_tags_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_datastore_maintenancemode_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_import_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_deploy_ovf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_dns_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_lic_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_drs_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_loadcfg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_drs_group_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_match_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_drs_rule_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_mgtconfig_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_dvs_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_nat_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_dvs_portgroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_object_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_dvs_portgroup_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_op_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_dvswitch_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_pg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_dvswitch_lacp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_query_rules_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_dvswitch_pvlans_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_restart_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_dvswitch_uplink_pg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_sag_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_export_ovf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_set_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_boot_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/panos_security_rule_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_boot_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_access_list_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_custom_attribute_defs_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_access_list_ip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_custom_attributes_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_cluster_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_datacenter_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_connection_stats_settings_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_customization_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_admin_service_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_disk_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_admin_session_timeout_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_disk_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_admin_syslog_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_cpu_class_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_file_operation_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_cpu_mgmt_class_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_find_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_dhcp_filter_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_powerstate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_dscp_map_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_move_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_dscp_map_pri_map_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_snapshot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_fabric_local_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_snapshot_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_igmp_snooping_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_tools_upgrade_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_ipv6security_raguard_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_tools_wait_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_ipv6security_raguard_port_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_video_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_ipv6security_raguard_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_guest_vnc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_log_audit_exception_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_ospf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_acceptance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_ospfarea_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_active_directory_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_port_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_capability_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_prefix_list_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_config_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_port_cos_bw_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_config_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_port_cos_rate_setting_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_datastore_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_prefix_list_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_dns_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_snmp_trap_sink_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_show_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_feature_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_role_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_firewall_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_snmp_community_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_firewall_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_snmp_vacm_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_hyperthreading_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_stp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_ipv6_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_stp_port_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_kernel_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_switch_setup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_lockdown_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_trunk_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_ntp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_ntp_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vflow_table_profile_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_package_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vlag_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_powermgmt_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vrouter_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_powerstate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_scanhba_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vrouter_bgp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_service_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vrouter_loopback_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_service_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vrouter_bgp_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_snmp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vrouter_ospf6_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_ssl_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vrouter_interface_ip_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_vmhba_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vrouter_ospf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_host_vmnic_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vrouter_packet_relay_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_local_role_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vrouter_pim_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_local_role_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vrouterif_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_local_user_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vrouterbgp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_local_user_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vrouterlbif_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_maintenancemode_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/pn_vtep_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_migrate_vmk_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/routeros_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_object_role_permission_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/routeros_api_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_portgroup_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/routeros_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_portgroup_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/slxos_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_resource_pool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/slxos_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_resource_pool_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/slxos_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_tag_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/slxos_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_tag_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/slxos_l2_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_tag_manager_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/slxos_l3_interface_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_target_canonical_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/slxos_linkagg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vcenter_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/slxos_lldp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vcenter_statistics_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/slxos_vlan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vm_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/sros_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vm_host_drs_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/sros_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vm_shell_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/sros_rollback_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vm_vm_drs_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/vdirect_commit_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vm_vss_dvs_migrate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/vdirect_runnable_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vmkernel_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/vdirect_file_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vmkernel_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/voss_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vmkernel_ip_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/voss_command_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vmotion_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/ce_netconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vsan_cluster_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/voss_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vspan_session_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/network/sros_netconf.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vswitch_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/proxysql/proxysql_backend_servers_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vmware_vswitch_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/proxysql/proxysql_global_variables_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vsphere_copy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/proxysql/proxysql_manage_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vsphere_file_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/proxysql/proxysql_query_rules_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_account_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/proxysql/proxysql_mysql_users_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_block_storage_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/proxysql/proxysql_replication_hostgroups_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_block_storage_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/proxysql/proxysql_scheduler_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_dns_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_lookup.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_dns_domain_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_binding_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_dns_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_exchange_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_firewall_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_global_parameter_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_firewall_group_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_plugin_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_firewall_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_parameter_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_network_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_network_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_publish_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_os_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_queue_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_plan_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_vhost_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_region_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_user_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_server_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_vhost_limits_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_server_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_tools_connection.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_ssh_key_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_httpapi.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_ssh_key_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vm_inventory_inventory.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_startup_script_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vca_fw_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_startup_script_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vca_nat_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vca_vapp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/vultr_user_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vcenter_extension_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/wait_for_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vcenter_extension_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/wait_for_connection_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vcenter_extension_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/wakeonlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vcenter_folder_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/webfaction_app_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vcenter_license_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/webfaction_db_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_category_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/webfaction_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_category_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/webfaction_mailbox_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_about_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/webfaction_site_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_about_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_acl_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_category_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_acl_inheritance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_cfg_backup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_audit_policy_system_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_cluster_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_audit_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_cluster_drs_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_certificate_store_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_cluster_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_chocolatey_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_cluster_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_chocolatey_config_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_cluster_ha_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_chocolatey_feature_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_cluster_vsan_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_chocolatey_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_content_library_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_chocolatey_source_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_content_library_manager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_copy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_content_deploy_ovf_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_credential_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_content_deploy_template_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_defrag_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_datacenter_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_disk_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_datacenter_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_disk_image_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_datastore_cluster_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_dns_client_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_datastore_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_dns_record_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_datastore_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_domain_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_datastore_maintenancemode_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_domain_computer_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_deploy_ovf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_domain_controller_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_dns_config_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_domain_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_drs_group_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_domain_group_membership_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_drs_group_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_domain_membership_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_drs_group_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_dotnet_ngen_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_drs_rule_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_domain_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_dvs_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_dsc_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_drs_rule_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_environment_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_dvs_portgroup_find_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_eventlog_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_dvs_portgroup_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_eventlog_entry_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_dvs_portgroup_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_feature_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_dvswitch_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_file_version_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_dvs_portgroup_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_file_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_dvswitch_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_find_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_dvswitch_lacp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_firewall_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_dvswitch_pvlans_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_firewall_rule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_dvswitch_nioc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_format_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_dvswitch_uplink_pg_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_evc_mode_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_group_membership_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_export_ovf_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_hostname_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_folder_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_hosts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_hotfix_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_boot_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_http_proxy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_boot_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_iis_virtualdirectory_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_boot_manager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_iis_webapplication_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_controller_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_iis_webapppool_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_cross_vc_clone_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_iis_webbinding_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_custom_attribute_defs_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_iis_website_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_custom_attributes_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_inet_proxy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_customization_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_lineinfile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_customization_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_mapped_drive_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_disk_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_msg_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_disk_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_optional_feature_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_disk_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_nssm_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_owner_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_find_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_pagefile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_file_operation_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_partition_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_path_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_move_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_pester_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_powerstate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_ping_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_network_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_power_plan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_register_operation_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_product_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_screenshot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_psexec_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_snapshot_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_psrepository_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_snapshot_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_rabbitmq_plugin_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_sendkey_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_rds_cap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_serial_port_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_rds_rap_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_snapshot_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_rds_settings_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_tools_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_reboot_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_tools_upgrade_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_reg_stat_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_tools_wait_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_regedit_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_region_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_vnc_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_regmerge_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_video_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_robocopy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_active_directory_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_route_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_acceptance_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_say_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_auto_start_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_scheduled_task_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_capability_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_scheduled_task_stat_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_capability_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_security_policy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_config_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_share_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_config_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_shortcut_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_config_manager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_snmp_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_datastore_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_psmodule_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_dns_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_tempfile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_dns_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_dns_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_timezone_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_toast_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_feature_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_updates_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_feature_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_uri_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_firewall_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_user_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_firewall_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_user_profile_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_firewall_manager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_user_right_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_hyperthreading_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_wait_for_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_ipv6_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_wait_for_process_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_kernel_manager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_wakeonlan_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_iscsi_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_webpicmd_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_lockdown_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_whoami_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_logbundle_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_xml_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_logbundle_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/win_service_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_ntp_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/xattr_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_ntp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/xbps_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_ntp_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/xenserver_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_package_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/xenserver_guest_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_package_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/xenserver_guest_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_powermgmt_policy_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/xenserver_guest_powerstate_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_scanhba_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/xfconf_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_powerstate_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/xfs_quota_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_service_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/xml_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_service_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/yarn_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_service_manager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/yum_repository_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_sriov_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zabbix_action_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_snmp_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zabbix_group_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_ssl_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zabbix_group_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_ssl_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zabbix_host_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_vmhba_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zabbix_host_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_vmhba_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zabbix_hostmacro_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_vmnic_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zabbix_maintenance_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_local_role_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zabbix_map_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_host_vmnic_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zabbix_proxy_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_local_role_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zabbix_screen_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_local_role_manager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zabbix_template_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_local_user_facts_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zfs_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_local_user_info_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zfs_delegate_admin_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_maintenancemode_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zfs_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_local_user_manager_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/znode_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_migrate_vmk_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zpool_facts_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_object_rename_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zypper_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_object_role_permission_module.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/modules/zypper_repository_module.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_portgroup_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_portgroup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_portgroup_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_resource_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_resource_pool_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_resource_pool_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_tag_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_tag_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_tag_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_target_canonical_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_tag_manager_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vc_infraprofile_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_target_canonical_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vcenter_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vcenter_settings_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vm_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vcenter_statistics_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vm_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vm_host_drs_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vm_shell_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vm_storage_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vm_storage_policy_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vm_vm_drs_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vmkernel_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vm_vss_dvs_migrate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vmkernel_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vmkernel_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vmotion_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vmkernel_ip_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vsan_cluster_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vsan_health_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vspan_session_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vswitch_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vswitch_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vswitch_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vsphere_copy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/vmware/vsphere_file_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/skydive/skydive_lookup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/skydive/skydive_capture_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/skydive/skydive_edge_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/skydive/skydive_node_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/laps_password_lookup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/psexec_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_audit_policy_system_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_audit_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_credential_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_auto_logon_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_data_deduplication_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_certificate_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_computer_description_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_defrag_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_disk_image_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_dhcp_lease_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_disk_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_dns_record_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_dns_zone_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_domain_computer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_domain_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_domain_group_membership_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_domain_object_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_domain_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_dotnet_ngen_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_eventlog_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_eventlog_entry_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_file_compression_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_file_version_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_firewall_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_firewall_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_format_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_hosts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_hotfix_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_http_proxy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_iis_virtualdirectory_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_iis_webapplication_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_iis_webapppool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_iis_webbinding_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_iis_website_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_inet_proxy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_initialize_disk_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_mapped_drive_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_lineinfile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_msg_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_netbios_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_nssm_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_pagefile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_partition_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_pester_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_power_plan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_product_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_psmodule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_psexec_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_psrepository_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_psmodule_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_psrepository_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_psscript_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_pssession_configuration_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_psscript_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_rds_cap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_rabbitmq_plugin_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_rds_rap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_region_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_rds_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_regmerge_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_robocopy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_say_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_route_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_scheduled_task_stat_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_scheduled_task_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_scoop_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_scoop_bucket_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_security_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_shortcut_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_snmp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_timezone_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_toast_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_unzip_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_user_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_wait_for_process_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_wakeonlan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_webpicmd_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/windows/win_xml_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_action_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_discovery_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_group_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_group_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_host_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_host_events_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_host_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_host_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_maintenance_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_hostmacro_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_map_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_mediatype_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_proxy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_screen_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_service_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_user_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_usergroup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_valuemap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cyberark/conjur/conjur_variable_lookup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/containers/podman/buildah_connection.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_template_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_container_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_network_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_container_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_connection.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_pod_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_volume_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_image_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_image_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cyberark/pas/cyberark_account_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_pod_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cyberark/pas/cyberark_credential_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os9/os9_cliconf.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cyberark/pas/cyberark_authentication_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os9/os9_command_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os9/os9_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/cyberark/pas/cyberark_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os9/os9_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os6/os6_cliconf.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os6/os6_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os6/os6_command_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fortimanager_httpapi.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os6/os6_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_antivirus_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_antivirus_profile_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_application_list_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_application_list_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_device_profile_fortianalyzer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_device_profile_fortiguard_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_log_syslogd_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_log_syslogd_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_system_dns_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_system_centralmanagement_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_system_emailserver_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_system_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_system_ntp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_system_snmp_community_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_system_snmp_community_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_system_snmp_sysinfo_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_system_snmp_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_devprof_system_snmp_user_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_dnsfilter_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_dnsfilter_profile_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_dvm_cmd_add_device_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_dvm_cmd_del_device_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_dvm_cmd_discover_device_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_dvm_cmd_update_device_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_dvmdb_device_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_dvmdb_device_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_dvmdb_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_dvmdb_script_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_dvmdb_group_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_dvmdb_script_execute_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_dvmdb_script_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_address_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_address6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_address6_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_address_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_addrgrp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_addrgrp6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_addrgrp6_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_addrgrp_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_ippool6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_ippool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_ippool6_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_ippool_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_multicastaddress_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_multicastaddress_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_profilegroup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_profilegroup_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_service_category_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_service_category_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_service_custom_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_service_custom_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_service_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_service_group_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_sslsshprofile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_sslsshprofile_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_vip_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_firewall_vip_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_ips_sensor_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_ips_sensor_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_pkg_firewall_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_pkg_firewall_policy_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_pm_devprof_adom_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_pm_devprof_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_pm_pkg_adom_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_securityconsole_install_device_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_pm_pkg_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_securityconsole_install_package_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_spamfilter_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_spamfilter_profile_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_system_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_system_ha_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_system_ha_peer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_system_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_system_interface_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_task_task_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_task_task_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_voip_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_voip_profile_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_waf_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_waf_profile_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_wanopt_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_wanopt_profile_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_webfilter_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_webfilter_profile_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_webproxy_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortimanager/fmgr_webproxy_profile_obj_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os10/os10_cliconf.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os10/base_xml_to_dict_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os10/bgp_validate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os10/mtu_validate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os10/os10_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os10/os10_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os10/os10_command_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os10/show_system_network_summary_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os10/vlt_validate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/dellemc/os10/wiring_validate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_license_lookup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/license_hopper_lookup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_apm_acl_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_apm_network_access_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_apm_policy_fetch_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_apm_policy_import_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_asm_advanced_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_asm_dos_application_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_asm_policy_fetch_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_asm_policy_server_technology_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_asm_policy_import_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_asm_policy_manage_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_asm_policy_signature_set_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_cgnat_lsn_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_cli_alias_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_cli_script_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_command_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_configsync_action_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_data_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_auth_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_auth_ldap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_auth_radius_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_auth_radius_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_certificate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_group_member_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_connectivity_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_dns_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_ha_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_httpd_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_ntp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_license_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_sshd_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_syslog_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_traffic_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_dns_cache_resolver_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_device_trust_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_dns_nameserver_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_dns_resolver_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_dns_zone_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_file_copy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_firewall_address_list_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_firewall_dos_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_firewall_global_rules_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_firewall_dos_vector_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_firewall_log_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_firewall_log_profile_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_firewall_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_firewall_port_list_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_firewall_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_firewall_rule_list_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_firewall_schedule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_datacenter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_dns_listener_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_monitor_bigip_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_monitor_external_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_monitor_firepass_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_monitor_http_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_monitor_https_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_monitor_tcp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_monitor_tcp_half_open_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_pool_member_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_topology_region_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_topology_record_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_virtual_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_gtm_wide_ip_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_hostname_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_iapp_service_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_ike_peer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_iapp_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_imish_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_ipsec_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_irule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_log_destination_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_log_publisher_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_lx_package_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_management_route_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_message_routing_protocol_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_message_routing_peer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_message_routing_router_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_message_routing_route_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_message_routing_transport_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_dns_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_ftp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_external_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_gateway_icmp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_http_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_https_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_ldap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_icmp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_mysql_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_oracle_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_smtp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_snmp_dca_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_tcp_echo_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_tcp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_tcp_half_open_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_monitor_udp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_network_globals_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_node_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_partition_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_password_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_policy_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_pool_member_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_analytics_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_client_ssl_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_dns_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_fastl4_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_ftp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_http_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_http_compression_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_http2_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_oneconnect_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_persistence_src_addr_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_persistence_cookie_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_server_ssl_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_persistence_universal_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_sip_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_tcp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_provision_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_profile_udp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_qkview_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_remote_role_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_remote_syslog_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_remote_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_routedomain_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_selfip_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_service_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_smtp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_snat_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_snmp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_snat_translation_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_snmp_community_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_snmp_trap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_software_image_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_software_install_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_software_update_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_ssl_certificate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_ssl_csr_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_static_route_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_ssl_key_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_ssl_ocsp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_sys_daemon_log_tmm_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_sys_db_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_sys_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_timer_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_traffic_selector_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_tunnel_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_trunk_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_ucs_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_ucs_fetch_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_vcmp_guest_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_virtual_address_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_virtual_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_vlan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigip_wait_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_application_fasthttp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_application_fastl4_tcp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_application_fastl4_udp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_application_http_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_application_https_offload_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_application_https_waf_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_device_discovery_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_device_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_regkey_license_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_regkey_license_assignment_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_utility_license_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_regkey_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/frr/frr/frr_cliconf.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/f5networks/f5_modules/bigiq_utility_license_assignment_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/frr/frr/frr_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/frr/frr/frr_bgp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_httpapi.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_antivirus_heuristic_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_alertemail_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_antivirus_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_antivirus_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_antivirus_quarantine_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_application_custom_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_application_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_authentication_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_application_list_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_application_name_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_authentication_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_certificate_crl_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_certificate_local_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_application_rule_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_authentication_scheme_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_dlp_fp_doc_source_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_dlp_fp_sensitivity_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_dlp_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_dnsfilter_domain_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_dnsfilter_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_dlp_filepattern_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_certificate_ca_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_dlp_sensor_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_endpoint_control_client_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_endpoint_control_forticlient_ems_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_endpoint_control_forticlient_registration_sync_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_endpoint_control_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_endpoint_control_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_endpoint_control_registered_forticlient_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_extender_controller_extender_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_address_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_address6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_address6_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_addrgrp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_auth_portal_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_central_snat_map_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_addrgrp6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_dnstranslation_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_dos_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_dos_policy6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_interface_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_identity_based_route_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_interface_policy6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_internet_service_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_internet_service_custom_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_internet_service_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ip_translation_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ipmacbinding_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ipmacbinding_table_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_internet_service_custom_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ippool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ippool6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ipv6_eh_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ldb_monitor_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_local_in_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_local_in_policy6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_multicast_address_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_multicast_address6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_multicast_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_multicast_policy6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_policy46_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_policy6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_policy64_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_profile_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_proxy_address_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_profile_protocol_options_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_proxy_addrgrp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_schedule_onetime_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_proxy_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_schedule_recurring_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_schedule_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_service_custom_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_service_category_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_service_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_shaper_traffic_shaper_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_shaper_per_ip_shaper_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_shaping_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_shaping_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_sniffer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ssh_host_key_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ssh_local_ca_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ssh_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ssh_local_key_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ssl_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ssl_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ssl_ssh_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_ttl_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_vip_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_vip46_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_vipgrp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_vip6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_vip64_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_vipgrp46_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_vipgrp6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_vipgrp64_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_wildcard_fqdn_custom_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_ftp_proxy_explicit_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_firewall_wildcard_fqdn_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_icap_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_icap_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_ips_custom_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_ips_decoder_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_ips_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_ips_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_ips_rule_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_ips_sensor_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_ips_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_custom_field_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_disk_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_disk_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_eventfilter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_fortianalyzer2_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_fortianalyzer2_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_fortianalyzer3_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_fortianalyzer3_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_fortianalyzer_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_fortianalyzer_override_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_fortianalyzer_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_fortianalyzer_override_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_fortiguard_override_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_fortiguard_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_fortiguard_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_fortiguard_override_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_gui_display_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_memory_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_memory_global_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_memory_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_null_device_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_null_device_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_syslogd2_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_syslogd3_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_syslogd4_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_syslogd4_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_syslogd2_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_syslogd3_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_syslogd_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_syslogd_override_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_syslogd_override_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_syslogd_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_threat_weight_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_webtrends_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_log_webtrends_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_registration_forticare_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_registration_vdom_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_report_dataset_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_report_chart_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_report_layout_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_report_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_report_style_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_report_theme_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_access_list_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_access_list6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_aspath_list_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_auth_path_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_bfd_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_bfd6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_bgp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_community_list_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_isis_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_multicast_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_key_chain_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_multicast6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_multicast_flow_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_ospf6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_ospf_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_policy6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_prefix_list_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_prefix_list6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_rip_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_static_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_static6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_route_map_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_router_ripng_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_spamfilter_bword_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_spamfilter_bwl_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_spamfilter_dnsbl_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_spamfilter_fortishield_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_spamfilter_iptrust_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_spamfilter_mheader_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_spamfilter_options_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_spamfilter_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_ssh_filter_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_802_1x_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_custom_command_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_igmp_snooping_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_lldp_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_lldp_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_mac_sync_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_managed_switch_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_network_monitor_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_qos_dot1p_map_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_qos_ip_dscp_map_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_qos_qos_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_qos_queue_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_quarantine_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_security_policy_802_1x_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_security_policy_captive_portal_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_sflow_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_stp_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_storm_control_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_switch_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_switch_interface_tag_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_switch_log_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_switch_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_virtual_port_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_system_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_switch_controller_vlan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_3g_modem_custom_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_admin_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_accprofile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_affinity_interrupt_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_affinity_packet_redistribution_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_alarm_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_alias_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_auto_install_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_api_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_arp_table_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_automation_action_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_auto_script_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_automation_destination_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_automation_trigger_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_automation_stitch_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_autoupdate_schedule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_autoupdate_push_update_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_central_management_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_autoupdate_tunneling_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_cluster_sync_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_console_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_config_backup_restore_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_csf_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_custom_language_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_ddns_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_dedicated_mgmt_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_dhcp_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_dns_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_dns_database_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_dscp_based_priority_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_dhcp6_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_dns_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_email_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_external_resource_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_fips_cc_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_fm_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_fortiguard_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_fortimanager_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_fsso_polling_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_fortisandbox_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_ftm_push_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_geoip_override_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_gre_tunnel_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_ha_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_ha_monitor_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_ipip_tunnel_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_ips_urlfilter_dns6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_ips_urlfilter_dns_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_ipv6_neighbor_cache_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_link_monitor_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_ipv6_tunnel_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_lte_modem_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_mac_address_table_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_management_tunnel_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_mobile_tunnel_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_nat64_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_modem_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_netflow_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_ntp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_network_visibility_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_object_tagging_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_password_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_password_policy_guest_admin_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_physical_switch_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_pppoe_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_probe_response_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_proxy_arp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_admin_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_alertmail_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_auth_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_device_detection_portal_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_fortiguard_wf_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_ec_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_ftp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_http_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_icap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_mail_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_image_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_nac_quar_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_nntp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_spam_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_sslvpn_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_utm_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_traffic_quota_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_replacemsg_webproxy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_resource_limits_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_sdn_connector_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_session_helper_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_session_ttl_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_sflow_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_sit_tunnel_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_snmp_sysinfo_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_sms_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_snmp_community_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_snmp_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_stp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_storage_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_switch_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_tos_based_priority_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_vdom_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_vdom_exception_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_vdom_dns_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_vdom_link_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_vdom_property_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_vdom_sflow_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_vdom_netflow_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_virtual_switch_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_vdom_radius_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_virtual_wan_link_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_vmlicense_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_virtual_wire_pair_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_vxlan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_zone_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_adgrp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_system_wccp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_device_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_device_access_list_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_device_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_device_category_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_domain_controller_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_fsso_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_fortitoken_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_fsso_polling_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_ldap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_krb_keytab_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_password_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_local_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_pop3_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_radius_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_peer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_peergrp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_quarantine_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_security_exempt_list_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_user_tacacsplus_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_voip_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_certificate_crl_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_certificate_ca_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_certificate_local_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_certificate_ocsp_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_certificate_remote_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_certificate_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ipsec_concentrator_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ipsec_forticlient_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ipsec_manualkey_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ipsec_phase1_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ipsec_manualkey_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ipsec_phase1_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ipsec_phase2_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ipsec_phase2_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ocvpn_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_l2tp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ssl_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ssl_web_host_check_software_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_pptp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ssl_web_portal_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ssl_web_realm_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ssl_web_user_group_bookmark_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_vpn_ssl_web_user_bookmark_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_waf_main_class_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_waf_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_waf_signature_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_waf_sub_class_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wanopt_auth_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wanopt_content_delivery_network_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wanopt_cache_service_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wanopt_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wanopt_peer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wanopt_remote_storage_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wanopt_settings_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_web_proxy_debug_url_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wanopt_webcache_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_web_proxy_explicit_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_web_proxy_forward_server_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_web_proxy_forward_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_web_proxy_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_web_proxy_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_webfilter_content_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_web_proxy_wisp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_web_proxy_url_match_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_webfilter_content_header_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_webfilter_fortiguard_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_webfilter_ftgd_local_cat_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_webfilter_ips_urlfilter_cache_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_webfilter_ftgd_local_rating_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_webfilter_ips_urlfilter_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_webfilter_ips_urlfilter_setting6_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_webfilter_override_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_webfilter_search_engine_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_webfilter_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_webfilter_urlfilter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_ap_status_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_ble_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_bonjour_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_hotspot20_anqp_3gpp_cellular_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_hotspot20_anqp_nai_realm_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_hotspot20_anqp_ip_address_type_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_hotspot20_anqp_network_auth_type_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_hotspot20_anqp_roaming_consortium_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_hotspot20_anqp_venue_name_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_hotspot20_h2qp_operator_name_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_hotspot20_h2qp_conn_capability_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_hotspot20_h2qp_osu_provider_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_hotspot20_hs_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_hotspot20_h2qp_wan_metric_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_hotspot20_icon_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_hotspot20_qos_map_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_inter_controller_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_qos_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_timers_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_utm_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_vap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_wids_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_vap_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_wtp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/qradar_httpapi.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_wtp_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/deploy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/fortinet/fortios/fortios_wireless_controller_wtp_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/offense_action_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/offense_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/log_source_management_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/offense_note_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/qradar_offense_action_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/qradar_deploy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/qradar_log_source_management_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/qradar_offense_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/qradar_rule_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/qradar_offense_note_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/qradar_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/rule_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/infinidat/infinibox/infini_cluster_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ibm/qradar/rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/infinidat/infinibox/infini_export_client_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/infinidat/infinibox/infini_export_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/infinidat/infinibox/infini_host_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/infinidat/infinibox/infini_fs_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/infinidat/infinibox/infini_map_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/infinidat/infinibox/infini_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/infinidat/infinibox/infini_port_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/infinidat/infinibox/infini_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/infinidat/infinibox/infini_vol_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/gluster/gluster/geo_rep_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/gluster/gluster/gluster_heal_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/gluster/gluster/gluster_peer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/gluster/gluster/gluster_volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_cliconf.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_acl_interfaces_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_acls_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_banner_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_command_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_interfaces_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_l2_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_l3_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_l2_interfaces_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_l3_interfaces_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_lacp_interfaces_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_lacp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_lag_interfaces_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_linkagg_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_lldp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_lldp_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_lldp_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_lldp_interfaces_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_logging_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_netconf_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_ospfv2_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_package_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_ping_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_rpc_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_scp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_static_route_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_static_routes_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_system_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_vlans_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_vlan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_vrf_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_netconf.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_cliconf.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_aaa_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_bfd_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_bgp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_buffer_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_command_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_igmp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_igmp_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_igmp_vlan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_l2_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_l3_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_lldp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_linkagg_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_lldp_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_magp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_mlag_ipl_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_mlag_vip_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_ntp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_ntp_servers_peers_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_ospf_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_ptp_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_pfc_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_protocol_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_qos_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_snmp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_ptp_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_snmp_hosts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_snmp_users_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_syslog_files_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_syslog_remote_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_traffic_class_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_username_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_vlan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_vxlan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/mellanox/onyx/onyx_wjh_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_access_group_volumes_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_access_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_account_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_admin_users_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_backup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_check_connections_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_cluster_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_cluster_pair_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_cluster_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_cluster_snmp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_drive_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_initiators_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_snapshot_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_network_interfaces_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_ldap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_node_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_snapshot_restore_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_snapshot_schedule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_volume_clone_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_volume_pair_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/elementsw/na_elementsw_vlan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_certificate_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_inventory.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_datacenter_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_certificate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_floating_ip_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_floating_ip_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_datacenter_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_image_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_floating_ip_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_load_balancer_service_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_load_balancer_target_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_image_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_load_balancer_type_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_location_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_load_balancer_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_load_balancer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_location_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_network_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_route_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_rdns_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_server_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_server_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_server_type_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_server_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_ssh_key_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_server_type_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_ssh_key_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_ssh_key_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_subnetwork_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_volume_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_volume_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_appengine_firewall_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_inventory.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_appengine_firewall_rule_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_bigquery_dataset_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_bigquery_dataset_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_bigquery_table_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_bigquery_table_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_bigtable_instance_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_bigtable_instance_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_cloudbuild_trigger_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_cloudfunctions_cloud_function_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_cloudbuild_trigger_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_cloudfunctions_cloud_function_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_cloudscheduler_job_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_cloudscheduler_job_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_cloudtasks_queue_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_cloudtasks_queue_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_address_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_address_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_autoscaler_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_autoscaler_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_backend_bucket_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_backend_bucket_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_backend_service_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_backend_service_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_disk_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_disk_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_external_vpn_gateway_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_external_vpn_gateway_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_firewall_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_firewall_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_forwarding_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_forwarding_rule_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_global_address_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_global_address_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_global_forwarding_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_global_forwarding_rule_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_health_check_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_health_check_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_http_health_check_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_http_health_check_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_https_health_check_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_https_health_check_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_image_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_image_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_group_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_group_manager_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_group_manager_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_interconnect_attachment_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_template_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_interconnect_attachment_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_network_endpoint_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_network_endpoint_group_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_network_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_node_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_node_group_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_node_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_node_template_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_autoscaler_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_autoscaler_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_backend_service_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_backend_service_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_disk_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_disk_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_health_check_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_health_check_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_instance_group_manager_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_instance_group_manager_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_target_http_proxy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_target_https_proxy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_target_http_proxy_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_target_https_proxy_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_url_map_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_region_url_map_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_reservation_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_reservation_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_resource_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_route_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_resource_policy_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_route_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_router_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_router_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_snapshot_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_ssl_certificate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_snapshot_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_ssl_certificate_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_ssl_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_ssl_policy_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_subnetwork_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_http_proxy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_subnetwork_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_http_proxy_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_https_proxy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_https_proxy_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_instance_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_instance_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_pool_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_ssl_proxy_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_ssl_proxy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_tcp_proxy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_tcp_proxy_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_vpn_gateway_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_url_map_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_target_vpn_gateway_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_url_map_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_vpn_tunnel_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_vpn_tunnel_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_cluster_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_cluster_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_node_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_node_pool_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_dns_managed_zone_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_dns_managed_zone_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_dns_resource_record_set_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_dns_resource_record_set_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_filestore_instance_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_filestore_instance_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_iam_service_account_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_iam_service_account_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_iam_role_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_iam_role_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_iam_service_account_key_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_kms_crypto_key_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_kms_crypto_key_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_kms_key_ring_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_kms_key_ring_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_logging_metric_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_logging_metric_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_mlengine_model_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_mlengine_version_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_mlengine_model_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_mlengine_version_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_pubsub_subscription_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_pubsub_subscription_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_redis_instance_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_pubsub_topic_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_pubsub_topic_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_redis_instance_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_resourcemanager_project_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_runtimeconfig_config_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_resourcemanager_project_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_runtimeconfig_variable_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_runtimeconfig_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_serviceusage_service_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_runtimeconfig_variable_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_serviceusage_service_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sourcerepo_repository_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sourcerepo_repository_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_spanner_database_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_spanner_database_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_spanner_instance_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_spanner_instance_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sql_database_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sql_instance_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sql_database_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sql_instance_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sql_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sql_ssl_cert_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sql_user_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_storage_bucket_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_storage_bucket_access_control_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_storage_default_object_acl_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_tpu_node_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_storage_object_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_tpu_node_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/aws/aws_netapp_cvs_active_directory_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/aws/aws_netapp_cvs_filesystems_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/aws/aws_netapp_cvs_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/aws/aws_netapp_cvs_snapshots_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/santricity_host_lookup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/santricity_host_detail_lookup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/santricity_storage_pool_lookup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_alerts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_alerts_syslog_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_asup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_auditlog_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_auth_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_client_certificate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_discover_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_drive_firmware_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_firmware_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_host_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_ib_iser_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_hostgroup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_iscsi_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_iscsi_target_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_ldap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_lun_mapping_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_mgmt_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_nvme_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_proxy_drive_firmware_upload_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_proxy_firmware_upload_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_proxy_systems_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_storagepool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_syslog_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/na_santricity_volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_alerts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_amg_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_amg_role_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_amg_sync_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_asup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_auth_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_drive_firmware_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_auditlog_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_firmware_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_flashcache_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_host_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_iscsi_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_hostgroup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_iscsi_target_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_ldap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_lun_mapping_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_mgmt_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_snapshot_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_snapshot_images_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_snapshot_volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_storage_system_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_storagepool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_syslog_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp_eseries/santricity/netapp_e_volume_copy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/nb_inventory_inventory.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/nb_lookup_lookup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_aggregate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_cable_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_circuit_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_circuit_termination_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_circuit_type_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_cluster_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_cluster_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_cluster_type_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_console_port_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_console_port_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_console_server_port_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_console_server_port_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_device_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_device_bay_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_device_bay_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_device_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_device_interface_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_device_role_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_device_type_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_front_port_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_front_port_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_inventory_item_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_ip_address_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_ipam_role_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_manufacturer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_platform_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_power_feed_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_power_outlet_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_power_outlet_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_power_panel_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_power_port_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_power_port_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_prefix_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_provider_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_rack_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_rack_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_rack_role_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_rear_port_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_rear_port_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_region_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_rir_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_service_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_site_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_tenant_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_tenant_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_virtual_chassis_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_virtual_machine_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_vlan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_vlan_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_vrf_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netbox/netbox/netbox_vm_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_affinitygroup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_account_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_cluster_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_configuration_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_disk_offering_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_domain_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_facts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_firewall_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_host_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_image_store_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_instance_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_instance_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_instance_nic_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_instance_nic_secondaryip_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_instance_password_reset_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_instancegroup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_ip_address_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_iso_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_loadbalancer_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_loadbalancer_rule_member_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_network_offering_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_network_acl_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_network_acl_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_physical_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_pod_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_portforward_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_project_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_region_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_role_permission_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_router_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_resourcelimit_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_role_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_securitygroup_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_securitygroup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_service_offering_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_snapshot_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_sshkeypair_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_staticnat_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_storage_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_vlan_ip_range_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_vmsnapshot_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_vpc_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_traffic_type_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_vpc_offering_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_vpn_connection_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_vpn_gateway_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_zone_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_zone_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/cloudstack/cs_vpn_customer_gateway_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_aggregate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_autosupport_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_cg_snapshot_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_broadcast_domain_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_cifs_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_cluster_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_cifs_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_cifs_acl_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_broadcast_domain_ports_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_autosupport_invoke_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_cluster_peer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_cluster_ha_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_disks_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_command_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_export_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_efficiency_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_dns_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_fcp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_export_policy_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_file_directory_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_firewall_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_igroup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_igroup_initiator_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_firmware_upgrade_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_flexcache_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_ipspace_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_iscsi_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_iscsi_security_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_job_schedule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_kerberos_realm_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_ldap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_ldap_client_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_login_messages_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_license_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_lun_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_lun_map_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_lun_copy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_motd_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_name_service_switch_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_ndmp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_net_ifgrp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_net_port_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_net_routes_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_net_subnet_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_net_vlan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_nfs_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_node_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_ntfs_dacl_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_ntfs_sd_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_ntp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_nvme_namespace_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_nvme_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_ports_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_portset_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_nvme_subsystem_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_qos_policy_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_object_store_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_quota_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_qos_adaptive_policy_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_qtree_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_rest_cli_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_quotas_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_restit_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_rest_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_security_certificates_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_service_processor_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_snapmirror_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_security_key_manager_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_snapshot_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_snapmirror_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_snmp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_snmp_traphosts_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_snapshot_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_software_update_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_ssh_command_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_svm_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_svm_options_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_unix_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_unix_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_ucadapter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_user_role_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_volume_autosize_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_volume_clone_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_volume_snaplock_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_vscan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_vscan_on_access_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_vscan_on_demand_task_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_vscan_scanner_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_vserver_cifs_security_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_vserver_peer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_wait_for_condition_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_wwpn_alias_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/netapp/ontap/na_ontap_zapit_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/exoscale/exo_dns_domain_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/exoscale/exo_dns_record_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_inventory.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_account_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_block_storage_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_block_storage_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_dns_domain_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_dns_domain_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_dns_record_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_firewall_group_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_firewall_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_firewall_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_network_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_os_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_plan_baremetal_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_plan_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_region_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_ssh_key_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_server_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_ssh_key_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_startup_script_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_server_baremetal_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_startup_script_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ngine_io/vultr/vultr_user_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/auth_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/openstack_inventory.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/baremetal_inspect_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/baremetal_node_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/baremetal_node_action_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/catalog_service_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/coe_cluster_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/coe_cluster_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/compute_flavor_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/compute_flavor_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/dns_zone_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/endpoint_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/federation_idp_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/federation_idp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/federation_mapping_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/floating_ip_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/federation_mapping_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/group_assignment_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/identity_domain_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/identity_domain_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/identity_group_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/identity_role_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/host_aggregate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/identity_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/identity_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/identity_user_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/image_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/image_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/keypair_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/keystone_federation_protocol_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/lb_listener_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/keystone_federation_protocol_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/lb_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/lb_member_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/loadbalancer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_auth_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_client_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/object_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/networks_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_coe_cluster_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_coe_cluster_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_flavor_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_floating_ip_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_group_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_image_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_ironic_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_image_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_ironic_inspect_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_ironic_node_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_keypair_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_keystone_domain_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_keystone_endpoint_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_keystone_domain_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_keystone_federation_protocol_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_keystone_federation_protocol_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_keystone_identity_provider_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_keystone_identity_provider_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_keystone_mapping_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_keystone_mapping_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_keystone_role_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_listener_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_keystone_service_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_loadbalancer_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_member_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_networks_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_nova_flavor_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_nova_host_aggregate_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_object_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_port_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_port_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_project_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_project_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_project_access_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_quota_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_router_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_recordset_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_routers_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_security_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_security_group_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_server_action_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_server_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_server_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_server_metadata_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_server_volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_stack_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_subnet_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_subnets_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_user_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_user_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_user_role_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_volume_snapshot_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/os_zone_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/port_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/project_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/port_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/project_access_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/quota_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/project_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/recordset_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/router_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/role_assignment_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/security_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/routers_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/security_group_rule_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/server_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/server_action_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/server_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/server_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/server_metadata_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/server_volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/subnet_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/stack_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/subnets_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/volume_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openstack/cloud/volume_snapshot_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_affinity_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_inventory.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_affinity_label_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_affinity_label_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_api_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_auth_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_cluster_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_cluster_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_datacenter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_datacenter_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_event_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_disk_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_disk_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_event_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_external_provider_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_group_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_external_provider_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_host_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_host_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_host_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_host_pm_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_host_storage_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_instance_type_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_mac_pool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_job_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_network_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_nic_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_nic_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_permission_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_permission_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_quota_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_quota_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_role_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_scheduling_policy_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_snapshot_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_snapshot_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_storage_domain_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_storage_connection_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_storage_domain_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_storage_template_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_storage_vm_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_tag_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_tag_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_template_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_user_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_vm_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_vm_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_vm_os_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_vmpool_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_vmpool_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_vnic_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_vnic_profile_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_alert_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_arrayname_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_banner_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_connect_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_console_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_dns_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_ds_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_dsrole_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_endpoint_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_eula_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_hg_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_host_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_inventory_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_ntp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_offload_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_pg_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_pgsched_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_pgsnap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_phonehome_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_pod_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_pod_replica_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_proxy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_ra_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_smis_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_smtp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_snap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_subnet_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_snmp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_syslog_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_timeout_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_vg_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_vlan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_vnc_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_volume_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flasharray/purefa_volume_tags_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openvswitch/openvswitch/openvswitch_bridge_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openvswitch/openvswitch/openvswitch_db_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/openvswitch/openvswitch/openvswitch_port_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_alert_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_bladename_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_bucket_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_connect_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_bucket_replica_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_dns_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_ds_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_dsrole_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_fs_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_fs_replica_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_inventory_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_ntp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_phonehome_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_policy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_proxy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_ra_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_remote_cred_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_s3acc_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_s3user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_smtp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_snap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_snmp_agent_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_snmp_mgr_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_subnet_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/purestorage/flashblade/purefb_target_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/splunk/es/splunk_httpapi.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/splunk/es/adaptive_response_notable_event_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/splunk/es/correlation_search_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/splunk/es/correlation_search_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/splunk/es/data_input_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/splunk/es/data_input_monitor_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/splunk/es/splunk_adaptive_response_notable_event_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/splunk/es/splunk_data_input_monitor_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/splunk/es/splunk_correlation_search_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/splunk/es/splunk_correlation_search_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/foreman_callback.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/foreman_inventory.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/splunk/es/splunk_data_input_network_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/architecture_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/activation_key_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/auth_source_ldap_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/bookmark_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/compute_attribute_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/compute_profile_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/config_group_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/compute_resource_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/content_credential_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/content_upload_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/content_view_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/content_view_filter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/content_view_version_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/domain_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/external_usergroup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/global_parameter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/hardware_model_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/host_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/host_collection_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/host_power_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/hostgroup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/http_proxy_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/image_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/installation_medium_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/lifecycle_environment_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/job_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/operatingsystem_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/location_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/organization_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/partition_table_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/os_default_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/product_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/provisioning_template_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/puppet_environment_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/repository_set_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/realm_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/redhat_manifest_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/repository_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/role_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/resource_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/scap_tailoring_file_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/repository_sync_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/scc_product_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/smart_class_parameter_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/scap_content_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/scc_account_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/snapshot_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/subscription_manifest_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/setting_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/subnet_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/sync_plan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/usergroup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/servicenow/servicenow/now_inventory.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/servicenow/servicenow/snow_record_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/templates_import_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/servicenow/servicenow/snow_record_find_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_cliconf.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_banner_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_command_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_firewall_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_firewall_interfaces_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_firewall_rules_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_l3_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_interfaces_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_l3_interfaces_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_linkagg_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_lag_interfaces_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_lldp_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_lldp_global_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_lldp_interface_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_lldp_interfaces_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_logging_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_ospfv2_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_ping_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_ospfv3_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_static_routes_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_static_route_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_system_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_user_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/vyos/vyos/vyos_vlan_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_status_lookup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_metering_lookup.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_alarm_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_config_backup_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_config_restore_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_firmware_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_current_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_interface_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_iptables_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_interface_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_plugcontrol_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_power_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_serial_port_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_iptables_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_plugconfig_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_serial_port_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_status_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_snmp_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_snmp_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_temp_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_time_config_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_time_info_module.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/collections/wti/remote/cpm_user_module.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing_validate-modules.html</loc>
@@ -10057,21 +15148,18 @@
     <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing_integration_legacy.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/dev_guide/testing_units_modules.html</loc>
-  </url>
-  <url>
     <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/scenario_clone_template.html</loc>
-  </url>
-  <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/scenario_rename_vm.html</loc>
   </url>
   <url>
     <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/scenario_remove_vm.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/scenario_find_vm_folder.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/scenario_vmware_http.html</loc>
   </url>
   <url>
-    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/scenario_vmware_http.html</loc>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/scenario_rename_vm.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.ansible.com/ansible/latest/scenario_guides/vmware_scenarios/scenario_find_vm_folder.html</loc>
   </url>
 </urlset>


### PR DESCRIPTION
Used nmp sitemap-generator-cli to regenerate the core site map for latest.

https://www.linuxsecrets.com/3585-creating-sitemap-in-linux-terminal

part of https://github.com/ansible/ansible/issues/70783