### PR TITLE
Edits to main index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@ h4 {
                             <a href="automation.html">
                                 <h4 class="card-title">Ansible Automation Platform Documentation</h4>
                             </a>
-                            <p class="card-text">Access the best of Ansible innovation with hardening and support from Red&nbsp;Hat. Learn how the elements of the Red Hat Ansible Automation Platform work together to centralize and control your IT infrastructure with visual dashboards, role-based access control, curated and supported Ansbile Collections, and&nbsp;more. Learn about Ansible Tower, Private Autmation Hub, Automation Services Catalog, and other Platform&nbsp;features.</p>
+                            <p class="card-text">Access the best of Ansible innovation with hardening and support from Red&nbsp;Hat. Learn how the elements of the Red Hat Ansible Automation Platform work together to centralize and control your IT infrastructure with visual dashboards, role-based access control, curated and supported Ansbile Collections, and&nbsp;more. Learn about Ansible Tower, Private Automation Hub, Automation Services Catalog, and other Platform&nbsp;features.</p>
                         </div>
                         <div class="card-footer">
                             <a href="automation.html" class="btn btn-outline-black">Learn more</a>


### PR DESCRIPTION
- Removes references to Red Hat hardening and support from the descriptions of the community offerings.
- Restores and end-quote to fix a dead link. 
- Fixes a typo reported on the Red Hat Ansible Automation Platform gchat channel