### PR TITLE
Updated links for automation.html and translated landing pages.

### DIFF
--- a/automation-tower-chinese-translations.html
+++ b/automation-tower-chinese-translations.html
@@ -303,30 +303,6 @@ h4 {
                     </a>
                 </div>
                 <div class="col-md-6 col-lg-4">
-                    <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/quickinstall/">
-                        <div class="card border">
-                            <div class="card-body">
-                                <h4 class="card-title">Simplified Chinese: automation controller 快速安装指南 <br/>version 4.0.0</h4>
-                            </div>
-                             <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/quickinstall/" class="btn btn-outline-black">Supported</a>
-                            </div>
-                        </div>
-                    </a>
-                </div>
-                <div class="col-md-6 col-lg-4">
-                    <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/installandreference/">
-                        <div class="card border">
-                            <div class="card-body">
-                                <h4 class="card-title">Simplified Chinese: automation controller 安装和参考指南 <br/>version 4.0.0</h4>
-                            </div>
-                             <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/installandreference/" class="btn btn-outline-black">Supported</a>
-                            </div>
-                        </div>
-                    </a>
-                </div>
-                <div class="col-md-6 col-lg-4">
                     <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/release-notes/">
                         <div class="card border">
                             <div class="card-body">
@@ -339,13 +315,13 @@ h4 {
                     </a>
                 </div>
                 <div class="col-md-6 col-lg-4">
-                    <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/towerapi/">
+                    <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/controllerapi/">
                         <div class="card border">
                             <div class="card-body">
                                 <h4 class="card-title">Simplified Chinese: automation controller API 指南  <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/towerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/controllerapi/" class="btn btn-outline-black">Supported</a>
                             </div>
                         </div>
                     </a>

--- a/automation-tower-japanese-translations.html
+++ b/automation-tower-japanese-translations.html
@@ -337,30 +337,6 @@ h4 {
                     </a>
                 </div>
                 <div class="col-md-6 col-lg-4">
-                    <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/quickinstall/">
-                        <div class="card border">
-                            <div class="card-body">
-                                <h4 class="card-title">Japanese: automation controller インストールガイド <br/>version 4.0.0</h4>
-                            </div>
-                             <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/quickinstall/" class="btn btn-outline-black">Supported</a>
-                            </div>
-                        </div>
-                    </a>
-                </div>
-                <div class="col-md-6 col-lg-4">
-                    <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/installandreference/">
-                        <div class="card border">
-                            <div class="card-body">
-                                <h4 class="card-title">Japanese: automation controller インストールおよびリファレンスガイド <br/>version 4.0.0</h4>
-                            </div>
-                             <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/installandreference/" class="btn btn-outline-black">Supported</a>
-                            </div>
-                        </div>
-                    </a>
-                </div>
-                <div class="col-md-6 col-lg-4">
                     <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/release-notes/">
                         <div class="card border">
                             <div class="card-body">
@@ -373,13 +349,13 @@ h4 {
                     </a>
                 </div>
                 <div class="col-md-6 col-lg-4">
-                    <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/towerapi/">
+                    <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/controllerapi/">
                         <div class="card border">
                             <div class="card-body">
                                 <h4 class="card-title">Japanese: automation controller ガイド  <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/towerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/controllerapi/" class="btn btn-outline-black">Supported</a>
                             </div>
                         </div>
                     </a>

--- a/automation.html
+++ b/automation.html
@@ -235,6 +235,7 @@ h4 {
                     <img src="https://static.redhat.com/libs/redhat/brand-assets/2/corp/logo--400.png" class="mb-3">
                     <h1 class="mb-2">Red Hat Ansible Automation Platform Docs</h1>
                     <p class="subhead">Access to the subscription based docs</p>
+                    <p>For those looking for older versions of the documentation <a href="automation-tower-prior-versions.html" class="btn btn-outline-black">Find your version</a></p>
                 </div>
             </div>
         </div>
@@ -324,40 +325,27 @@ h4 {
                     </a>
                 </div>
                 <div class="col-md-6 col-lg-4">
-                    <a href="https://docs.ansible.com/automation-controller/latest/html/towerapi/index.html">
+                    <a href="https://docs.ansible.com/automation-controller/latest/html/controllerapi/index.html">
                         <div class="card border">
                             <div class="card-body">
                                 <h4 class="card-title">Automation Controller API guide</h4>
                                 <p class="card-text">Learn and explore the Automation Controller API</p>
                             </div>
                             <div class="card-footer">
-                            <a href="https://docs.ansible.com/automation-controller/latest/html/towerapi/index.html" class="btn btn-outline-black">Learn more</a>
+                            <a href="https://docs.ansible.com/automation-controller/latest/html/controllerapi/index.html" class="btn btn-outline-black">Learn more</a>
                             </div>
                         </div>
                     </a>
                 </div>
                 <div class="col-md-6 col-lg-4">
-                    <a href="https://docs.ansible.com/automation-controller/latest/html/towercli/index.html">
+                    <a href="https://docs.ansible.com/automation-controller/latest/html/controllercli/index.html">
                         <div class="card border">
                             <div class="card-body">
                                 <h4 class="card-title">Automation Controller CLI guide</h4>
                                 <p class="card-text">Learn about the official command line client for AWX and the automation controller</p>
                             </div>
                             <div class="card-footer">
-                            <a href="https://docs.ansible.com/automation-controller/latest/html/towercli/index.html" class="btn btn-outline-black">Learn more</a>
-                            </div>
-                        </div>
-                    </a>
-                </div>
-                <div class="col-md-6 col-lg-4">
-                    <a href="automation-tower-prior-versions.html">
-                        <div class="card border">
-                            <div class="card-body">
-                                <h4 class="card-title">Automation Controller Previous versions</h4>
-                                <p class="card-text">For those looking for older versions of the documentation</p>
-                            </div>
-                            <div class="card-footer">
-                            <a href="automation-tower-prior-versions.html" class="btn btn-outline-black">Find your version</a>
+                            <a href="https://docs.ansible.com/automation-controller/latest/html/controllercli/index.html" class="btn btn-outline-black">Learn more</a>
                             </div>
                         </div>
                     </a>


### PR DESCRIPTION
For 4.0 versions - Changes to automation.html:
- Renamed link for API and CLI guides from `html/towerapi/index.html` to `html/controllerapi/index.html` `html/towercli/index.html` to `html/controllercli/index.html` respectively
- Removed previous versions card from bottom and promoted link up top per @gamuniz's suggestion (and @docschick's concurrence)
See rendered version here: http://docs.testing.ansible.com/automation.html

For 4.0 versions - Changes to automation-tower-japanese-translations.html and automation-tower-chinese-translations.html:
- Removed cards for Installation and Reference Guide and Quick Install guides
- Modified link for API guides from `html/towerapi/index.html` to `html/controllerapi/index.html` 
See rendered versions here:
  - http://docs.testing.ansible.com/automation-tower-japanese-translations.html
  - http://docs.testing.ansible.com/automation-tower-chinese-translations.html