### PR TITLE
updates link for 2.11 core translation

### DIFF
--- a/core-translated-ja.html
+++ b/core-translated-ja.html
@@ -272,14 +272,14 @@ h4 {
                     </a>
                 </div>
                 <div class="col-md-6 col-lg-4">
-                    <a href="https://docs.ansible.com/ansible-core/2.11/html_ja/index.html">
+                    <a href="https://docs.ansible.com/ansible-core/2.11_ja/index.html">
                         <div class="card border">
                             <div class="card-body">
                                 <h4 class="card-title">ansible-core ドキュメント 2.11</h4>
                                 <p class="card-text"></p>
                             </div>
                             <div class="card-footer">
-                                <a href="https://docs.ansible.com/ansible-core/2.11/html_ja/index.html" class="btn btn-outline-black">Learn more</a>
+                                <a href="https://docs.ansible.com/ansible-core/2.11_ja/index.html" class="btn btn-outline-black">Learn more</a>
                             </div>
 
                         </div>


### PR DESCRIPTION
In the first round, the 2.11 core docs in Japanese were manually published to https://docs.ansible.com/ansible-core/2.11/html_ja/index.html.

Moving forward, we plan to publish them with the same job and the same URL pattern as the 2.9 Japanese docs. The new URL should be:
https://docs.ansible.com/ansible-core/2.11_ja/index.html

This PR updates the links from the landing pages to the new URL for the 2.11 core docs in Japanese.
