### PR TITLE
Tower: Add 3.8.4 in prior list

### DIFF
--- a/automation-tower-prior-versions.html
+++ b/automation-tower-prior-versions.html
@@ -243,6 +243,18 @@ h4 {
         <div class="container">
             <div class="row">
                 <div class="col-md-6 col-lg-4">
+                    <a href="https://docs.ansible.com/ansible-tower/3.8.4/html/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Automation: Tower,<br/>version 3.8.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="https://docs.ansible.com/ansible-tower/3.8.4/html/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
                     <a href="https://docs.ansible.com/ansible-tower/3.8.3/html/">
                         <div class="card border">
                             <div class="card-body">


### PR DESCRIPTION
Platform  1.2.5 has been released as of yesterday. This allows for customer to find the documentation for it.