### PR TITLE
Added end-slash "/" at end of URL to 2.1 link

### DIFF
--- a/automation.html
+++ b/automation.html
@@ -247,7 +247,7 @@ h4 {
         <div class="container">
             <div class="row">
                 <div class="col-md-6 col-lg-4">
-                    <a href="https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/">
+                    <a href="https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/">
                         <div class="card border">
                             <div class="card-body">
                                 <h4 class="card-title">Ansible Automation Platform Hosted Services docs</h4>


### PR DESCRIPTION
Attempt to fix link still not going to 2.1 docs.