### PR TITLE
404 by version

### DIFF
--- a/ansible/2.10/.htaccess
+++ b/ansible/2.10/.htaccess
@@ -1,3 +1,6 @@
+Options -MultiViews
+ErrorDocument 404 /ansible/2.10/404.html
+
 RedirectMatch "^(/ansible/[^/]+)/plugins/become/doas.html" "$1/collections/community/general/doas_become.html"
 RedirectMatch "^(/ansible/[^/]+)/plugins/become/dzdo.html" "$1/collections/community/general/dzdo_become.html"
 RedirectMatch "^(/ansible/[^/]+)/plugins/become/enable.html" "$1/collections/ansible/netcommon/enable_become.html"

--- a/ansible/2.9/.htaccess
+++ b/ansible/2.9/.htaccess
@@ -1,3 +1,6 @@
+Options -MultiViews
+ErrorDocument 404 /ansible/2.9/404.html
+
 RedirectMatch "^(/ansible/[^/]+)/collections/community/general/doas_become.html" "$1/plugins/become/doas.html"
 RedirectMatch "^(/ansible/[^/]+)/collections/community/general/dzdo_become.html" "$1/plugins/become/dzdo.html"
 RedirectMatch "^(/ansible/[^/]+)/collections/ansible/netcommon/enable_become.html" "$1/plugins/become/enable.html"

--- a/ansible/3/.htaccess
+++ b/ansible/3/.htaccess
@@ -1,3 +1,6 @@
+Options -MultiViews
+ErrorDocument 404 /ansible/3/404.html
+
 RedirectMatch "^(/ansible/[^/]+)/plugins/become/doas.html" "$1/collections/community/general/doas_become.html"
 RedirectMatch "^(/ansible/[^/]+)/plugins/become/dzdo.html" "$1/collections/community/general/dzdo_become.html"
 RedirectMatch "^(/ansible/[^/]+)/plugins/become/enable.html" "$1/collections/ansible/netcommon/enable_become.html"

--- a/ansible/4/.htaccess
+++ b/ansible/4/.htaccess
@@ -1,3 +1,6 @@
+Options -MultiViews
+ErrorDocument 404 /ansible/r4/404.html
+
 RedirectMatch "^(/ansible/[^/]+)/plugins/become/doas.html" "$1/collections/community/general/doas_become.html"
 RedirectMatch "^(/ansible/[^/]+)/plugins/become/dzdo.html" "$1/collections/community/general/dzdo_become.html"
 RedirectMatch "^(/ansible/[^/]+)/plugins/become/enable.html" "$1/collections/ansible/netcommon/enable_become.html"

--- a/ansible/4/.htaccess
+++ b/ansible/4/.htaccess
@@ -1,5 +1,5 @@
 Options -MultiViews
-ErrorDocument 404 /ansible/r4/404.html
+ErrorDocument 404 /ansible/4/404.html
 
 RedirectMatch "^(/ansible/[^/]+)/plugins/become/doas.html" "$1/collections/community/general/doas_become.html"
 RedirectMatch "^(/ansible/[^/]+)/plugins/become/dzdo.html" "$1/collections/community/general/dzdo_become.html"

--- a/ansible/devel/.htaccess
+++ b/ansible/devel/.htaccess
@@ -1,0 +1,2 @@
+Options -MultiViews
+ErrorDocument 404 /ansible/devel/404.html


### PR DESCRIPTION
This is the final stage in making the 404 page version specific. Need to merge https://github.com/ansible/ansible/pull/77186 and backport this to 2.12, 2.11, 2.10, and 2.9 before merging this PR.