### PR TITLE
Adds  4.1.4 and missing versions from Ja, Zh, and Ko

### DIFF
--- a/automation-tower-chinese-translations.html
+++ b/automation-tower-chinese-translations.html
@@ -1065,7 +1065,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: automation controller 快速入门指南 <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/quickstart" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/quickstart" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1077,7 +1077,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: automation controller 发行注记 <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/release-notes/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/release-notes/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1089,7 +1089,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: automation controller API 指南  <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/controllerapi/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/controllerapi/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1101,7 +1101,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: automation controller 管理指南 <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/administration/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/administration/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1113,7 +1113,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: automation controller 用户指南 <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/userguide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/userguide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1125,7 +1125,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: automation controller 升级和迁移指南 <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1860,7 +1860,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速入门指南 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/quickstart" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/quickstart" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1872,7 +1872,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速安装指南 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/quickinstall/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/quickinstall/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1884,7 +1884,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 安装和参考指南 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/installandreference/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/installandreference/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1896,7 +1896,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 发行注记 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/release-notes/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/release-notes/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1908,7 +1908,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower API 指南  <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/towerapi/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/towerapi/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1920,7 +1920,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 管理指南 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/administration/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/administration/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1932,7 +1932,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 用户指南 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/userguide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/userguide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1944,7 +1944,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 升级和迁移指南 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1977,7 +1977,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速入门指南 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/quickstart" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/quickstart" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1989,7 +1989,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速安装指南 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/quickinstall/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/quickinstall/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2001,7 +2001,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 安装和参考指南 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/installandreference/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/installandreference/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2013,7 +2013,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 发行注记 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/release-notes/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/release-notes/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2025,7 +2025,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower API 指南  <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/towerapi/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/towerapi/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2037,7 +2037,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 管理指南 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/administration/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/administration/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2049,7 +2049,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 用户指南 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/userguide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/userguide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2061,7 +2061,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 升级和迁移指南 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2094,7 +2094,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速入门指南 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/quickstart" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/quickstart" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2106,7 +2106,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速安装指南 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/quickinstall/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/quickinstall/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2118,7 +2118,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 安装和参考指南 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/installandreference/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/installandreference/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2130,7 +2130,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 发行注记 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/release-notes/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/release-notes/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2142,7 +2142,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower API 指南  <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/towerapi/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/towerapi/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2154,7 +2154,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 管理指南 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/administration/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/administration/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2166,7 +2166,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 用户指南 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/userguide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/userguide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2178,7 +2178,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 升级和迁移指南 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2211,7 +2211,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速入门指南 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/quickstart" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/quickstart" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2223,7 +2223,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速安装指南 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/quickinstall/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/quickinstall/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2235,7 +2235,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 安装和参考指南 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/installandreference/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/installandreference/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2247,7 +2247,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 发行注记 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/release-notes/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/release-notes/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2259,7 +2259,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower API 指南  <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/towerapi/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/towerapi/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2271,7 +2271,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 管理指南 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/administration/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/administration/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2283,7 +2283,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 用户指南 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/userguide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/userguide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2295,7 +2295,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 升级和迁移指南 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2385,7 +2385,7 @@ h4 {
     *  License: MIT
     */
 
-    !function(a){"use strict";function b(a,b,c){"addEventListener"in window?a.addEventListener(b,c,!1):"attachEvent"in window&&a.attachEvent("on"+b,c)}function c(a,b,c){"removeEventListener"in window?a.removeEventListener(b,c,!1):"detachEvent"in window&&a.detachEvent("on"+b,c)}function d(){var a,b=["moz","webkit","o","ms"];for(a=0;a<b.length&&!N;a+=1)N=window[b[a]+"RequestAnimationFrame"];N||h("setup","RequestAnimationFrame not supported")}function e(a){var b="Host page: "+a;return window.top!==window.self&&(b=window.parentIFrame&&window.parentIFrame.getId?window.parentIFrame.getId()+": "+a:"Nested host page: "+a),b}function f(a){return K+"["+e(a)+"]"}function g(a){return P[a]?P[a].log:G}function h(a,b){k("log",a,b,g(a))}function i(a,b){k("info",a,b,g(a))}function j(a,b){k("warn",a,b,!0)}function k(a,b,c,d){!0===d&&"object"==typeof window.console&&console[a](f(b),c)}function l(a){function d(){function a(){s(U),p(V),I("resizedCallback",U)}f("Height"),f("Width"),t(a,U,"init")}function e(){var a=T.substr(L).split(":");return{iframe:P[a[0]]&&P[a[0]].iframe,id:a[0],height:a[1],width:a[2],type:a[3]}}function f(a){var b=Number(P[V]["max"+a]),c=Number(P[V]["min"+a]),d=a.toLowerCase(),e=Number(U[d]);h(V,"Checking "+d+" is in range "+c+"-"+b),c>e&&(e=c,h(V,"Set "+d+" to min value")),e>b&&(e=b,h(V,"Set "+d+" to max value")),U[d]=""+e}function g(){function b(){function a(){var a=0,b=!1;for(h(V,"Checking connection is from allowed list of origins: "+d);a<d.length;a++)if(d[a]===c){b=!0;break}return b}function b(){var a=P[V]&&P[V].remoteHost;return h(V,"Checking connection is from: "+a),c===a}return d.constructor===Array?a():b()}var c=a.origin,d=P[V]&&P[V].checkOrigin;if(d&&""+c!="null"&&!b())throw new Error("Unexpected message received from: "+c+" for "+U.iframe.id+". Message was: "+a.data+". This error can be disabled by setting the checkOrigin: false option or by providing of array of trusted domains.");return!0}function k(){return K===(""+T).substr(0,L)&&T.substr(L).split(":")[0]in P}function l(){var a=U.type in{"true":1,"false":1,undefined:1};return a&&h(V,"Ignoring init message from meta parent page"),a}function w(a){return T.substr(T.indexOf(":")+J+a)}function y(a){h(V,"MessageCallback passed: {iframe: "+U.iframe.id+", message: "+a+"}"),I("messageCallback",{iframe:U.iframe,message:JSON.parse(a)}),h(V,"--")}function z(){var a=document.body.getBoundingClientRect(),b=U.iframe.getBoundingClientRect();return JSON.stringify({iframeHeight:b.height,iframeWidth:b.width,clientHeight:Math.max(document.documentElement.clientHeight,window.innerHeight||0),clientWidth:Math.max(document.documentElement.clientWidth,window.innerWidth||0),offsetTop:parseInt(b.top-a.top,10),offsetLeft:parseInt(b.left-a.left,10),scrollTop:window.pageYOffset,scrollLeft:window.pageXOffset})}function A(a,b){function c(){u("Send Page Info","pageInfo:"+z(),a,b)}x(c,32)}function B(){function a(a,b){function c(){P[f]?A(P[f].iframe,f):d()}["scroll","resize"].forEach(function(d){h(f,a+d+" listener for sendPageInfo"),b(window,d,c)})}function d(){a("Remove ",c)}function e(){a("Add ",b)}var f=V;e(),P[f]&&(P[f].stopPageInfo=d)}function C(){P[V]&&P[V].stopPageInfo&&(P[V].stopPageInfo(),delete P[V].stopPageInfo)}function D(){var a=!0;return null===U.iframe&&(j(V,"IFrame ("+U.id+") not found"),a=!1),a}function E(a){var b=a.getBoundingClientRect();return o(V),{x:Math.floor(Number(b.left)+Number(M.x)),y:Math.floor(Number(b.top)+Number(M.y))}}function F(a){function b(){M=f,G(),h(V,"--")}function c(){return{x:Number(U.width)+e.x,y:Number(U.height)+e.y}}function d(){window.parentIFrame?window.parentIFrame["scrollTo"+(a?"Offset":"")](f.x,f.y):j(V,"Unable to scroll to requested position, window.parentIFrame not found")}var e=a?E(U.iframe):{x:0,y:0},f=c();h(V,"Reposition requested from iFrame (offset x:"+e.x+" y:"+e.y+")"),window.top!==window.self?d():b()}function G(){!1!==I("scrollCallback",M)?p(V):q()}function H(a){function b(){var a=E(f);h(V,"Moving to in page link (#"+d+") at x: "+a.x+" y: "+a.y),M={x:a.x,y:a.y},G(),h(V,"--")}function c(){window.parentIFrame?window.parentIFrame.moveToAnchor(d):h(V,"In page link #"+d+" not found and window.parentIFrame not found")}var d=a.split("#")[1]||"",e=decodeURIComponent(d),f=document.getElementById(e)||document.getElementsByName(e)[0];f?b():window.top!==window.self?c():h(V,"In page link #"+d+" not found")}function I(a,b){return m(V,a,b)}function N(){switch(P[V]&&P[V].firstRun&&S(),U.type){case"close":P[V].closeRequestCallback?m(V,"closeRequestCallback",P[V].iframe):n(U.iframe);break;case"message":y(w(6));break;case"scrollTo":F(!1);break;case"scrollToOffset":F(!0);break;case"pageInfo":A(P[V]&&P[V].iframe,V),B();break;case"pageInfoStop":C();break;case"inPageLink":H(w(9));break;case"reset":r(U);break;case"init":d(),I("initCallback",U.iframe);break;default:d()}}function O(a){var b=!0;return P[a]||(b=!1,j(U.type+" No settings for "+a+". Message was: "+T)),b}function Q(){for(var a in P)u("iFrame requested init",v(a),document.getElementById(a),a)}function S(){P[V]&&(P[V].firstRun=!1)}var T=a.data,U={},V=null;"[iFrameResizerChild]Ready"===T?Q():k()?(U=e(),V=R=U.id,P[V]&&(P[V].loaded=!0),!l()&&O(V)&&(h(V,"Received: "+T),D()&&g()&&N())):i(V,"Ignored: "+T)}function m(a,b,c){var d=null,e=null;if(P[a]){if(d=P[a][b],"function"!=typeof d)throw new TypeError(b+" on iFrame["+a+"] is not a function");e=d(c)}return e}function n(a){var b=a.id;h(b,"Removing iFrame: "+b),a.parentNode&&a.parentNode.removeChild(a),m(b,"closedCallback",b),h(b,"--"),delete P[b]}function o(b){null===M&&(M={x:window.pageXOffset!==a?window.pageXOffset:document.documentElement.scrollLeft,y:window.pageYOffset!==a?window.pageYOffset:document.documentElement.scrollTop},h(b,"Get page position: "+M.x+","+M.y))}function p(a){null!==M&&(window.scrollTo(M.x,M.y),h(a,"Set page position: "+M.x+","+M.y),q())}function q(){M=null}function r(a){function b(){s(a),u("reset","reset",a.iframe,a.id)}h(a.id,"Size reset requested by "+("init"===a.type?"host page":"iFrame")),o(a.id),t(b,a,"reset")}function s(a){function b(b){a.iframe.style[b]=a[b]+"px",h(a.id,"IFrame ("+e+") "+b+" set to "+a[b]+"px")}function c(b){H||"0"!==a[b]||(H=!0,h(e,"Hidden iFrame detected, creating visibility listener"),y())}function d(a){b(a),c(a)}var e=a.iframe.id;P[e]&&(P[e].sizeHeight&&d("height"),P[e].sizeWidth&&d("width"))}function t(a,b,c){c!==b.type&&N?(h(b.id,"Requesting animation frame"),N(a)):a()}function u(a,b,c,d,e){function f(){var e=P[d]&&P[d].targetOrigin;h(d,"["+a+"] Sending msg to iframe["+d+"] ("+b+") targetOrigin: "+e),c.contentWindow.postMessage(K+b,e)}function g(){j(d,"["+a+"] IFrame("+d+") not found")}function i(){c&&"contentWindow"in c&&null!==c.contentWindow?f():g()}function k(){function a(){!P[d]||P[d].loaded||l||(l=!0,j(d,"IFrame has not responded within "+P[d].warningTimeout/1e3+" seconds. Check iFrameResizer.contentWindow.js has been loaded in iFrame. This message can be ingored if everything is working, or you can set the warningTimeout option to a higher value or zero to suppress this warning."))}e&&P[d]&&P[d].warningTimeout&&(P[d].msgTimeout=setTimeout(a,P[d].warningTimeout))}var l=!1;d=d||c.id,P[d]&&(i(),k())}function v(a){return a+":"+P[a].bodyMarginV1+":"+P[a].sizeWidth+":"+P[a].log+":"+P[a].interval+":"+P[a].enablePublicMethods+":"+P[a].autoResize+":"+P[a].bodyMargin+":"+P[a].heightCalculationMethod+":"+P[a].bodyBackground+":"+P[a].bodyPadding+":"+P[a].tolerance+":"+P[a].inPageLinks+":"+P[a].resizeFrom+":"+P[a].widthCalculationMethod}function w(c,d){function e(){function a(a){1/0!==P[x][a]&&0!==P[x][a]&&(c.style[a]=P[x][a]+"px",h(x,"Set "+a+" = "+P[x][a]+"px"))}function b(a){if(P[x]["min"+a]>P[x]["max"+a])throw new Error("Value for min"+a+" can not be greater than max"+a)}b("Height"),b("Width"),a("maxHeight"),a("minHeight"),a("maxWidth"),a("minWidth")}function f(){var a=d&&d.id||S.id+F++;return null!==document.getElementById(a)&&(a+=F++),a}function g(a){return R=a,""===a&&(c.id=a=f(),G=(d||{}).log,R=a,h(a,"Added missing iframe ID: "+a+" ("+c.src+")")),a}function i(){switch(h(x,"IFrame scrolling "+(P[x]&&P[x].scrolling?"enabled":"disabled")+" for "+x),c.style.overflow=!1===(P[x]&&P[x].scrolling)?"hidden":"auto",P[x]&&P[x].scrolling){case!0:c.scrolling="yes";break;case!1:c.scrolling="no";break;default:c.scrolling=P[x]?P[x].scrolling:"no"}}function k(){("number"==typeof(P[x]&&P[x].bodyMargin)||"0"===(P[x]&&P[x].bodyMargin))&&(P[x].bodyMarginV1=P[x].bodyMargin,P[x].bodyMargin=""+P[x].bodyMargin+"px")}function l(){var a=P[x]&&P[x].firstRun,b=P[x]&&P[x].heightCalculationMethod in O;!a&&b&&r({iframe:c,height:0,width:0,type:"init"})}function m(){Function.prototype.bind&&P[x]&&(P[x].iframe.iFrameResizer={close:n.bind(null,P[x].iframe),resize:u.bind(null,"Window resize","resize",P[x].iframe),moveToAnchor:function(a){u("Move to anchor","moveToAnchor:"+a,P[x].iframe,x)},sendMessage:function(a){a=JSON.stringify(a),u("Send Message","message:"+a,P[x].iframe,x)}})}function o(d){function e(){u("iFrame.onload",d,c,a,!0),l()}b(c,"load",e),u("init",d,c,a,!0)}function p(a){if("object"!=typeof a)throw new TypeError("Options is not an object")}function q(a){for(var b in S)S.hasOwnProperty(b)&&(P[x][b]=a.hasOwnProperty(b)?a[b]:S[b])}function s(a){return""===a||"file://"===a?"*":a}function t(a){a=a||{},P[x]={firstRun:!0,iframe:c,remoteHost:c.src.split("/").slice(0,3).join("/")},p(a),q(a),P[x]&&(P[x].targetOrigin=!0===P[x].checkOrigin?s(P[x].remoteHost):"*")}function w(){return x in P&&"iFrameResizer"in c}var x=g(c.id);w()?j(x,"Ignored iFrame, already setup."):(t(d),i(),e(),k(),o(v(x)),m())}function x(a,b){null===Q&&(Q=setTimeout(function(){Q=null,a()},b))}function y(){function a(){function a(a){function b(b){return"0px"===(P[a]&&P[a].iframe.style[b])}function c(a){return null!==a.offsetParent}P[a]&&c(P[a].iframe)&&(b("height")||b("width"))&&u("Visibility change","resize",P[a].iframe,a)}for(var b in P)a(b)}function b(b){h("window","Mutation observed: "+b[0].target+" "+b[0].type),x(a,16)}function c(){var a=document.querySelector("body"),c={attributes:!0,attributeOldValue:!1,characterData:!0,characterDataOldValue:!1,childList:!0,subtree:!0},e=new d(b);e.observe(a,c)}var d=window.MutationObserver||window.WebKitMutationObserver;d&&c()}function z(a){function b(){B("Window "+a,"resize")}h("window","Trigger event: "+a),x(b,16)}function A(){function a(){B("Tab Visable","resize")}"hidden"!==document.visibilityState&&(h("document","Trigger event: Visiblity change"),x(a,16))}function B(a,b){function c(a){return P[a]&&"parent"===P[a].resizeFrom&&P[a].autoResize&&!P[a].firstRun}for(var d in P)c(d)&&u(a,b,document.getElementById(d),d)}function C(){b(window,"message",l),b(window,"resize",function(){z("resize")}),b(document,"visibilitychange",A),b(document,"-webkit-visibilitychange",A),b(window,"focusin",function(){z("focus")}),b(window,"focus",function(){z("focus")})}function D(){function b(a,b){function c(){if(!b.tagName)throw new TypeError("Object is not a valid DOM element");if("IFRAME"!==b.tagName.toUpperCase())throw new TypeError("Expected <IFRAME> tag, found <"+b.tagName+">")}b&&(c(),w(b,a),e.push(b))}function c(a){a&&a.enablePublicMethods&&j("enablePublicMethods option has been removed, public methods are now always available in the iFrame")}var e;return d(),C(),function(d,f){switch(e=[],c(d),typeof f){case"undefined":case"string":Array.prototype.forEach.call(document.querySelectorAll(f||"iframe"),b.bind(a,d));break;case"object":b(d,f);break;default:throw new TypeError("Unexpected data type ("+typeof f+")")}return e}}function E(a){a.fn?a.fn.iFrameResize||(a.fn.iFrameResize=function(a){function b(b,c){w(c,a)}return this.filter("iframe").each(b).end()}):i("","Unable to bind to jQuery, it is not fully loaded.")}if("undefined"!=typeof window){var F=0,G=!1,H=!1,I="message",J=I.length,K="[iFrameSizer]",L=K.length,M=null,N=window.requestAnimationFrame,O={max:1,scroll:1,bodyScroll:1,documentElementScroll:1},P={},Q=null,R="Host Page",S={autoResize:!0,bodyBackground:null,bodyMargin:null,bodyMarginV1:8,bodyPadding:null,checkOrigin:!0,inPageLinks:!1,enablePublicMethods:!0,heightCalculationMethod:"bodyOffset",id:"iFrameResizer",interval:32,log:!1,maxHeight:1/0,maxWidth:1/0,minHeight:0,minWidth:0,resizeFrom:"parent",scrolling:!1,sizeHeight:!0,sizeWidth:!1,warningTimeout:5e3,tolerance:0,widthCalculationMethod:"scroll",closedCallback:function(){},initCallback:function(){},messageCallback:function(){j("MessageCallback function not defined")},resizedCallback:function(){},scrollCallback:function(){return!0}};window.jQuery&&E(window.jQuery),"function"==typeof define&&define.amd?define([],D):"object"==typeof module&&"object"==typeof module.exports?module.exports=D():window.iFrameResize=window.iFrameResize||D()}}();
+    !function(a){"use strict";function b(a,b,c){"addEventListener"in window?a.addEventListener(b,c,!1):"attachEvent"in window&&a.attachEvent("on"+b,c)}function c(a,b,c){"removeEventListener"in window?a.removeEventListener(b,c,!1):"detachEvent"in window&&a.detachEvent("on"+b,c)}function d(){var a,b=["moz","webkit","o","ms"];for(a=0;a<b.length&&!N;a+=1)N=window[b[a]+"RequestAnimationFrame"];N||h("setup","RequestAnimationFrame not supported")}function e(a){var b="Host page: "+a;return window.top!==window.self&&(b=window.parentIFrame&&window.parentIFrame.getId?window.parentIFrame.getId()+": "+a:"Nested host page: "+a),b}function f(a){return K+"["+e(a)+"]"}function g(a){return P[a]?P[a].log:G}function h(a,b){k("log",a,b,g(a))}function i(a,b){k("info",a,b,g(a))}function j(a,b){k("warn",a,b,!0)}function k(a,b,c,d){!0===d&&"object"==typeof window.console&&console[a](f(b),c)}function l(a){function d(){function a(){s(U),p(V),I("resizedCallback",U)}f("Height"),f("Width"),t(a,U,"init")}function e(){var a=T.substr(L).split(":");return{iframe:P[a[0]]&&P[a[0]].iframe,id:a[0],height:a[1],width:a[2],type:a[3]}}function f(a){var b=Number(P[V]["max"+a]),c=Number(P[V]["min"+a]),d=a.toLowerCase(),e=Number(U[d]);h(V,"Checking "+d+" is in range "+c+"-"+b),c>e&&(e=c,h(V,"Set "+d+" to min value")),e>b&&(e=b,h(V,"Set "+d+" to max value")),U[d]=""+e}function g(){function b(){function a(){var a=0,b=!1;for(h(V,"Checking connection is from allowed list of origins: "+d);a<d.length;a++)if(d[a]===c){b=!0;break}return b}function b(){var a=P[V]&&P[V].remoteHost;return h(V,"Checking connection is from: "+a),c===a}return d.constructor===Array?a():b()}var c=a.origin,d=P[V]&&P[V].checkOrigin;if(d&&""+c!="null"&&!b())throw new Error("Unexpected message received from: "+c+" for "+U.iframe.id+". Message was: "+a.data+". This error can be disabled by setting the checkOrigin: false option or by providing of array of trusted domains.");return!0}function k(){return K===(""+T).substr(0,L)&&T.substr(L).split(":")[0]in P}function l(){var a=U.type in{"true":1,"false":1,undefined:1};return a&&h(V,"Ignoring init message from meta parent page"),a}function w(a){return T.substr(T.indexOf(":")+J+a)}function y(a){h(V,"MessageCallback passed: {iframe: "+U.iframe.id+", message: "+a+"}"),I("messageCallback",{iframe:U.iframe,message:JSON.parse(a)}),h(V,"--")}function z(){var a=document.body.getBoundingClientRect(),b=U.iframe.getBoundingClientRect();return JSON.stringify({iframeHeight:b.height,iframeWidth:b.width,clientHeight:Math.max(document.documentElement.clientHeight,window.innerHeight||0),clientWidth:Math.max(document.documentElement.clientWidth,window.innerWidth||0),offsetTop:parseInt(b.top-a.top,10),offsetLeft:parseInt(b.left-a.left,10),scrollTop:window.pageYOffset,scrollLeft:window.pageXOffset})}function A(a,b){function c(){u("Send Page Info","pageInfo:"+z(),a,b)}x(c,32)}function B(){function a(a,b){function c(){P[f]?A(P[f].iframe,f):d()}["scroll","resize"].forEach(function(d){h(f,a+d+" listener for sendPageInfo"),b(window,d,c)})}function d(){a("Remove ",c)}function e(){a("Add ",b)}var f=V;e(),P[f]&&(P[f].stopPageInfo=d)}function C(){P[V]&&P[V].stopPageInfo&&(P[V].stopPageInfo(),delete P[V].stopPageInfo)}function D(){var a=!0;return null===U.iframe&&(j(V,"IFrame ("+U.id+") not found"),a=!1),a}function E(a){var b=a.getBoundingClientRect();return o(V),{x:Math.floor(Number(b.left)+Number(M.x)),y:Math.floor(Number(b.top)+Number(M.y))}}function F(a){function b(){M=f,G(),h(V,"--")}function c(){return{x:Number(U.width)+e.x,y:Number(U.height)+e.y}}function d(){window.parentIFrame?window.parentIFrame["scrollTo"+(a?"Offset":"")](f.x,f.y):j(V,"Unable to scroll to requested position, window.parentIFrame not found")}var e=a?E(U.iframe):{x:0,y:0},f=c();h(V,"Reposition requested from iFrame (offset x:"+e.x+" y:"+e.y+")"),window.top!==window.self?d():b()}function G(){!1!==I("scrollCallback",M)?p(V):q()}function H(a){function b(){var a=E(f);h(V,"Moving to in page link (#"+d+") at x: "+a.x+" y: "+a.y),M={x:a.x,y:a.y},G(),h(V,"--")}function c(){window.parentIFrame?window.parentIFrame.moveToAnchor(d):h(V,"In page link #"+d+" not found and window.parentIFrame not found")}var d=a.split("#")[1]||"",e=decodeURIComponent(d),f=document.getElementById(e)||document.getElementsByName(e)[0];f?b():window.top!==window.self?c():h(V,"In page link #"+d+" not found")}function I(a,b){return m(V,a,b)}function N(){switch(P[V]&&P[V].firstRun&&S(),U.type){case"close":P[V].closeRequestCallback?m(V,"closeRequestCallback",P[V].iframe):n(U.iframe);break;case"message":y(w(6));break;case"scrollTo":F(!1);break;case"scrollToOffset":F(!0);break;case"pageInfo":A(P[V]&&P[V].iframe,V),B();break;case"pageInfoStop":C();break;case"inPageLink":H(w(9));break;case"reset":r(U);break;case"init":d(),I("initCallback",U.iframe);break;default:d()}}function O(a){var b=!0;return P[a]||(b=!1,j(U.type+" No settings for "+a+". Message was: "+T)),b}function Q(){for(var a in P)u("iFrame requested init",v(a),document.getElementById(a),a)}function S(){P[V]&&(P[V].firstRun=!1)}var T=a.data,U={},V=null;"[iFrameResizerChild]Ready"===T?Q():k()?(U=e(),V=R=U.id,P[V]&&(P[V].loaded=!0),!l()&&O(V)&&(h(V,"Received: "+T),D()&&g()&&N())):i(V,"Ignored: "+T)}function m(a,b,c){var d=null,e=null;if(P[a]){if(d=P[a][b],"function"!=typeof d)throw new TypeError(b+" on iFrame["+a+"] is not a function");e=d(c)}return e}function n(a){var b=a.id;h(b,"Removing iFrame: "+b),a.parentNode&&a.parentNode.removeChild(a),m(b,"closedCallback",b),h(b,"--"),delete P[b]}function o(b){null===M&&(M={x:window.pageXOffset!==a?window.pageXOffset:document.documentElement.scrollLeft,y:window.pageYOffset!==a?window.pageYOffset:document.documentElement.scrollTop},h(b,"Get page position: "+M.x+","+M.y))}function p(a){null!==M&&(window.scrollTo(M.x,M.y),h(a,"Set page position: "+M.x+","+M.y),q())}function q(){M=null}function r(a){function b(){s(a),u("reset","reset",a.iframe,a.id)}h(a.id,"Size reset requested by "+("init"===a.type?"host page":"iFrame")),o(a.id),t(b,a,"reset")}function s(a){function b(b){a.iframe.style[b]=a[b]+"px",h(a.id,"IFrame ("+e+") "+b+" set to "+a[b]+"px")}function c(b){H||"0"!==a[b]||(H=!0,h(e,"Hidden iFrame detected, creating visibility listener"),y())}function d(a){b(a),c(a)}var e=a.iframe.id;P[e]&&(P[e].sizeHeight&&d("height"),P[e].sizeWidth&&d("width"))}function t(a,b,c){c!==b.type&&N?(h(b.id,"Requesting animation frame"),N(a)):a()}function u(a,b,c,d,e){function f(){var e=P[d]&&P[d].targetOrigin;h(d,"["+a+"] Sending msg to iframe["+d+"] ("+b+") targetOrigin: "+e),c.contentWindow.postMessage(K+b,e)}function g(){j(d,"["+a+"] IFrame("+d+") not found")}function i(){c&&"contentWindow"in c&&null!==c.contentWindow?f():g()}function k(){function a(){!P[d]||P[d].loaded||l||(l=!0,j(d,"IFrame has not responded within "+P[d].warningTimeout/1e3+" seconds. Check iFrameResizer.contentWindow.js has been loaded in iFrame. This message can be ingored if everything is working, or you can set the warningTimeout option to a higher value or zero to suppress this warning."))}e&&P[d]&&P[d].warningTimeout&&(P[d].msgTimeout=setTimeout(a,P[d].warningTimeout))}var l=!1;d=d||c.id,P[d]&&(i(),k())}function v(a){return a+":"+P[a].bodyMarginV1+":"+P[a].sizeWidth+":"+P[a].log+":"+P[a].interval+":"+P[a].enablePublicMethods+":"+P[a].autoResize+":"+P[a].bodyMargin+":"+P[a].heightCalculationMethod+":"+P[a].bodyBackground+":"+P[a].bodyPadding+":"+P[a].tolerance+":"+P[a].inPageLinks+":"+P[a].resizeFrom+":"+P[a].widthCalculationMethod}function w(c,d){function e(){function a(a){1/0!==P[x][a]&&0!==P[x][a]&&(c.style[a]=P[x][a]+"px",h(x,"Set "+a+" = "+P[x][a]+"px"))}function b(a){if(P[x]["min"+a]>P[x]["max"+a])throw new Error("Value for min"+a+" can not be greater than max"+a)}b("Height"),b("Width"),a("maxHeight"),a("minHeight"),a("maxWidth"),a("minWidth")}function f(){var a=d&&d.id||S.id+F++;return null!==document.getElementById(a)&&(a+=F++),a}function g(a){return R=a,""===a&&(c.id=a=f(),G=(d||{}).log,R=a,h(a,"Added missing iframe ID: "+a+" ("+c.src+")")),a}function i(){switch(h(x,"IFrame scrolling "+(P[x]&&P[x].scrolling?"enabled":"disabled")+" for "+x),c.style.overflow=!1===(P[x]&&P[x].scrolling)?"hidden":"auto",P[x]&&P[x].scrolling){case!0:c.scrolling="yes";break;case!1:c.scrolling="no";break;default:c.scrolling=P[x]?P[x].scrolling:"no"}}function k(){("number"==typeof(P[x]&&P[x].bodyMargin)||"0"===(P[x]&&P[x].bodyMargin))&&(P[x].bodyMarginV1=P[x].bodyMargin,P[x].bodyMargin=""+P[x].bodyMargin+"px")}function l(){var a=P[x]&&P[x].firstRun,b=P[x]&&P[x].heightCalculationMethod in O;!a&&b&&r({iframe:c,height:0,width:0,type:"init"})}function m(){Function.prototype.bind&&P[x]&&(P[x].iframe.iFrameResizer={close:n.bind(null,P[x].iframe),resize:u.bind(null,"Window resize","resize",P[x].iframe),moveToAnchor:function(a){u("Move to anchor","moveToAnchor:"+a,P[x].iframe,x)},sendMessage:function(a){a=JSON.stringify(a),u("Send Message","message:"+a,P[x].iframe,x)}})}function o(d){function e(){u("iFrame.onload",d,c,a,!0),l()}b(c,"load",e),u("init",d,c,a,!0)}function p(a){if("object"!=typeof a)throw new TypeError("Options is not an object")}function q(a){for(var b in S)S.hasOwnProperty(b)&&(P[x][b]=a.hasOwnProperty(b)?a[b]:S[b])}function s(a){return""===a||"file://"===a?"*":a}function t(a){a=a||{},P[x]={firstRun:!0,iframe:c,remoteHost:c.src.split("/").slice(0,3).join("/")},p(a),q(a),P[x]&&(P[x].targetOrigin=!0===P[x].checkOrigin?s(P[x].remoteHost):"*")}function w(){return x in P&&"iFrameResizer"in c}var x=g(c.id);w()?j(x,"Ignored iFrame, already setup."):(t(d),i(),e(),k(),o(v(x)),m())}function x(a,b){null===Q&&(Q=setTimeout(function(){Q=null,a()},b))}function y(){function a(){function a(a){function b(b){return"0px"===(P[a]&&P[a].iframe.style[b])}function c(a){return null!==a.offsetParent}P[a]&&c(P[a].iframe)&&(b("height")||b("width"))&&u("Visibility change","resize",P[a].iframe,a)}for(var b in P)a(b)}function b(b){h("window","Mutation observed: "+b[0].target+" "+b[0].type),x(a,16)}function c(){var a=document.querySelector("body"),c={attributes:!0,attributEnd of Maintenance Support - EOLdValue:!1,characterData:!0,characterDataOldValue:!1,childList:!0,subtree:!0},e=new d(b);e.observe(a,c)}var d=window.MutationObserver||window.WebKitMutationObserver;d&&c()}function z(a){function b(){B("Window "+a,"resize")}h("window","Trigger event: "+a),x(b,16)}function A(){function a(){B("Tab Visable","resize")}"hidden"!==document.visibilityState&&(h("document","Trigger event: Visiblity change"),x(a,16))}function B(a,b){function c(a){return P[a]&&"parent"===P[a].resizeFrom&&P[a].autoResize&&!P[a].firstRun}for(var d in P)c(d)&&u(a,b,document.getElementById(d),d)}function C(){b(window,"message",l),b(window,"resize",function(){z("resize")}),b(document,"visibilitychange",A),b(document,"-webkit-visibilitychange",A),b(window,"focusin",function(){z("focus")}),b(window,"focus",function(){z("focus")})}function D(){function b(a,b){function c(){if(!b.tagName)throw new TypeError("Object is not a valid DOM element");if("IFRAME"!==b.tagName.toUpperCase())throw new TypeError("Expected <IFRAME> tag, found <"+b.tagName+">")}b&&(c(),w(b,a),e.push(b))}function c(a){a&&a.enablePublicMethods&&j("enablePublicMethods option has been removed, public methods are now always available in the iFrame")}var e;return d(),C(),function(d,f){switch(e=[],c(d),typeof f){case"undefined":case"string":Array.prototype.forEach.call(document.querySelectorAll(f||"iframe"),b.bind(a,d));break;case"object":b(d,f);break;default:throw new TypeError("Unexpected data type ("+typeof f+")")}return e}}function E(a){a.fn?a.fn.iFrameResize||(a.fn.iFrameResize=function(a){function b(b,c){w(c,a)}return this.filter("iframe").each(b).end()}):i("","Unable to bind to jQuery, it is not fully loaded.")}if("undefined"!=typeof window){var F=0,G=!1,H=!1,I="message",J=I.length,K="[iFrameSizer]",L=K.length,M=null,N=window.requestAnimationFrame,O={max:1,scroll:1,bodyScroll:1,documentElementScroll:1},P={},Q=null,R="Host Page",S={autoResize:!0,bodyBackground:null,bodyMargin:null,bodyMarginV1:8,bodyPadding:null,checkOrigin:!0,inPageLinks:!1,enablePublicMethods:!0,heightCalculationMethod:"bodyOffset",id:"iFrameResizer",interval:32,log:!1,maxHeight:1/0,maxWidth:1/0,minHeight:0,minWidth:0,resizeFrom:"parent",scrolling:!1,sizeHeight:!0,sizeWidth:!1,warningTimeout:5e3,tolerance:0,widthCalculationMethod:"scroll",closedCallback:function(){},initCallback:function(){},messageCallback:function(){j("MessageCallback function not defined")},resizedCallback:function(){},scrollCallback:function(){return!0}};window.jQuery&&E(window.jQuery),"function"==typeof define&&define.amd?define([],D):"object"==typeof module&&"object"==typeof module.exports?module.exports=D():window.iFrameResize=window.iFrameResize||D()}}();
     //# sourceMappingURL=iframeResizer.map
 
     $(document).ready(function(){

--- a/automation-tower-chinese-translations.html
+++ b/automation-tower-chinese-translations.html
@@ -242,7 +242,16 @@ h4 {
                         <a class="nav-link" href="#4.3.0">4.3.0</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="#4.2.1">4.2.1</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="#4.2.0">4.2.0</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#4.1.4">4.1.4</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#4.1.3">4.1.3</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="#4.1.2">4.1.2</a>
@@ -384,6 +393,98 @@ h4 {
                 </div>
 </div></div></section>
 
+<!-- Begin version 4.2.1 -->
+    <header class="headline py-5">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col text-center">
+                     <a id="4.2.1">
+                    <p class="subhead">automation controller 4.2.1</p>
+                </a>
+                </div>
+            </div>
+        </div>
+    </header>
+    <!-- End version 4.2.1 -->
+
+    <!-- BEGIN MAIN CARDS for Chinese 4.2.1 -->
+    <section class="cards pt-0">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_zh/quickstart">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 快速入门指南 <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_zh/quickstart" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_zh/release-notes/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 发行注记 <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_zh/release-notes/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_zh/controllerapi/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller API 指南  <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_zh/controllerapi/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_zh/administration/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 管理指南 <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_zh/administration/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_zh/userguide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 用户指南 <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_zh/userguide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_zh/upgrade-migration-guide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 升级和迁移指南 <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+</div></div></section>
+
 <!-- Begin version 4.2.0 -->
     <header class="headline py-5">
         <div class="container">
@@ -470,6 +571,190 @@ h4 {
                             </div>
                              <div class="card-footer">
                             <a href="http://docs.ansible.com/automation-controller/4.2.0/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+</div></div></section>
+
+<!-- Begin version 4.1.4 -->
+    <header class="headline py-5">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col text-center">
+                     <a id="4.1.4">
+                    <p class="subhead">automation controller 4.1.4</p>
+                </a>
+                </div>
+            </div>
+        </div>
+    </header>
+    <!-- End version 4.1.4 -->
+
+    <!-- BEGIN MAIN CARDS for Chinese 4.1.4 -->
+    <section class="cards pt-0">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.4/html_zh/quickstart">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 快速入门指南 <br/>version 4.1.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.4/html_zh/quickstart" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.4/html_zh/release-notes/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 发行注记 <br/>version 4.1.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.4/html_zh/release-notes/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.4/html_zh/controllerapi/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller API 指南  <br/>version 4.1.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.4/html_zh/controllerapi/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.4/html_zh/administration/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 管理指南 <br/>version 4.1.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.4/html_zh/administration/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.4/html_zh/userguide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 用户指南 <br/>version 4.1.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.4/html_zh/userguide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.4/html_zh/upgrade-migration-guide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 升级和迁移指南 <br/>version 4.1.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.4/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+</div></div></section>
+
+<!-- Begin version 4.1.3 -->
+    <header class="headline py-5">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col text-center">
+                     <a id="4.1.3">
+                    <p class="subhead">automation controller 4.1.3</p>
+                </a>
+                </div>
+            </div>
+        </div>
+    </header>
+    <!-- End version 4.1.3 -->
+
+    <!-- BEGIN MAIN CARDS for Chinese 4.1.3 -->
+    <section class="cards pt-0">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.3/html_zh/quickstart">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 快速入门指南 <br/>version 4.1.3</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.3/html_zh/quickstart" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.3/html_zh/release-notes/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 发行注记 <br/>version 4.1.3</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.3/html_zh/release-notes/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.3/html_zh/controllerapi/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller API 指南  <br/>version 4.1.3</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.3/html_zh/controllerapi/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.3/html_zh/administration/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 管理指南 <br/>version 4.1.3</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.3/html_zh/administration/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.3/html_zh/userguide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 用户指南 <br/>version 4.1.3</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.3/html_zh/userguide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.3/html_zh/upgrade-migration-guide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Simplified Chinese: automation controller 升级和迁移指南 <br/>version 4.1.3</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.3/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
                             </div>
                         </div>
                     </a>
@@ -780,7 +1065,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: automation controller 快速入门指南 <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/quickstart" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/quickstart" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -792,7 +1077,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: automation controller 发行注记 <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/release-notes/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/release-notes/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -804,7 +1089,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: automation controller API 指南  <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/controllerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/controllerapi/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -816,7 +1101,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: automation controller 管理指南 <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/administration/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/administration/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -828,7 +1113,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: automation controller 用户指南 <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/userguide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/userguide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -840,7 +1125,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: automation controller 升级和迁移指南 <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1575,7 +1860,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速入门指南 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/quickstart" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/quickstart" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1587,7 +1872,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速安装指南 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/quickinstall/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/quickinstall/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1599,7 +1884,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 安装和参考指南 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/installandreference/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/installandreference/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1611,7 +1896,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 发行注记 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/release-notes/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/release-notes/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1623,7 +1908,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower API 指南  <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/towerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/towerapi/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1635,7 +1920,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 管理指南 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/administration/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/administration/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1647,7 +1932,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 用户指南 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/userguide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/userguide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1659,7 +1944,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 升级和迁移指南 <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1692,7 +1977,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速入门指南 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/quickstart" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/quickstart" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1704,7 +1989,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速安装指南 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/quickinstall/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/quickinstall/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1716,7 +2001,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 安装和参考指南 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/installandreference/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/installandreference/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1728,7 +2013,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 发行注记 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/release-notes/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/release-notes/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1740,7 +2025,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower API 指南  <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/towerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/towerapi/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1752,7 +2037,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 管理指南 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/administration/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/administration/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1764,7 +2049,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 用户指南 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/userguide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/userguide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1776,7 +2061,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 升级和迁移指南 <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1809,7 +2094,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速入门指南 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/quickstart" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/quickstart" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1821,7 +2106,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速安装指南 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/quickinstall/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/quickinstall/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1833,7 +2118,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 安装和参考指南 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/installandreference/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/installandreference/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1845,7 +2130,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 发行注记 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/release-notes/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/release-notes/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1857,7 +2142,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower API 指南  <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/towerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/towerapi/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1869,7 +2154,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 管理指南 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/administration/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/administration/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1881,7 +2166,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 用户指南 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/userguide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/userguide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1893,7 +2178,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 升级和迁移指南 <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1926,7 +2211,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速入门指南 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/quickstart" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/quickstart" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1938,7 +2223,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 快速安装指南 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/quickinstall/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/quickinstall/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1950,7 +2235,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 安装和参考指南 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/installandreference/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/installandreference/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1962,7 +2247,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 发行注记 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/release-notes/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/release-notes/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1974,7 +2259,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower API 指南  <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/towerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/towerapi/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1986,7 +2271,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 管理指南 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/administration/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/administration/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1998,7 +2283,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 用户指南 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/userguide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/userguide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2010,7 +2295,7 @@ h4 {
                                 <h4 class="card-title">Simplified Chinese: Ansible Tower 升级和迁移指南 <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_zh/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>

--- a/automation-tower-japanese-translations.html
+++ b/automation-tower-japanese-translations.html
@@ -901,7 +901,6 @@ h4 {
     </header>
     <!-- End version 4.1.1 -->
 
-
     <!-- BEGIN MAIN CARDS for Japanese 4.1.1 -->
     <section class="cards pt-0">
         <div class="container">

--- a/automation-tower-japanese-translations.html
+++ b/automation-tower-japanese-translations.html
@@ -242,7 +242,16 @@ h4 {
                         <a class="nav-link" href="#4.3.0">4.3.0</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="#4.2.1">4.2.1</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="#4.2.0">4.2.0</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#4.1.4">4.1.4</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#4.1.3">4.1.3</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="#4.1.2">4.1.2</a>
@@ -418,6 +427,98 @@ h4 {
                 </div>
 </div></div></section>
 
+<!-- Begin version 4.2.1 -->
+    <header class="headline py-5">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col text-center">
+                    <a id="4.2.1">
+                    <p class="subhead">automation controller 4.2.1</p>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </header>
+    <!-- End version 4.2.1 -->
+
+    <!-- BEGIN MAIN CARDS for Japanese 4.2.1 -->
+    <section class="cards pt-0">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ja/quickstart">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller クイック設定ガイド <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ja/quickstart" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ja/release-notes/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller リリースノート <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ja/release-notes/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ja/controllerapi/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller API ガイド  <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ja/controllerapi/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ja/administration/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller 管理ガイド <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ja/administration/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ja/userguide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller ユーザーガイド <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ja/userguide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ja/upgrade-migration-guide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller のアップグレードおよび移行ガイド <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+</div></div></section>
+
 <!-- Begin version 4.2.0 -->
     <header class="headline py-5">
         <div class="container">
@@ -504,6 +605,190 @@ h4 {
                             </div>
                              <div class="card-footer">
                             <a href="http://docs.ansible.com/automation-controller/4.2.0/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+</div></div></section>
+
+<!-- Begin version 4.1.4 -->
+    <header class="headline py-5">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col text-center">
+                    <a id="4.1.4">
+                    <p class="subhead">automation controller 4.1.4</p>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </header>
+    <!-- End version 4.1.4 -->
+
+    <!-- BEGIN MAIN CARDS for Japanese 4.1.4 -->
+    <section class="cards pt-0">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.4/html_ja/quickstart">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller クイック設定ガイド <br/>version 4.1.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.4/html_ja/quickstart" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.4/html_ja/release-notes/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller リリースノート <br/>version 4.1.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.4/html_ja/release-notes/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.4/html_ja/controllerapi/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller API ガイド  <br/>version 4.1.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.4/html_ja/controllerapi/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.4/html_ja/administration/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller 管理ガイド <br/>version 4.1.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.4/html_ja/administration/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.4/html_ja/userguide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller ユーザーガイド <br/>version 4.1.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.4/html_ja/userguide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.4/html_ja/upgrade-migration-guide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller のアップグレードおよび移行ガイド <br/>version 4.1.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.4/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+</div></div></section>
+
+<!-- Begin version 4.1.3 -->
+    <header class="headline py-5">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col text-center">
+                    <a id="4.1.3">
+                    <p class="subhead">automation controller 4.1.3</p>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </header>
+    <!-- End version 4.1.3 -->
+
+    <!-- BEGIN MAIN CARDS for Japanese 4.1.3 -->
+    <section class="cards pt-0">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.3/html_ja/quickstart">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller クイック設定ガイド <br/>version 4.1.3</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.3/html_ja/quickstart" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.3/html_ja/release-notes/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller リリースノート <br/>version 4.1.3</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.3/html_ja/release-notes/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.3/html_ja/controllerapi/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller API ガイド  <br/>version 4.1.3</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.3/html_ja/controllerapi/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.3/html_ja/administration/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller 管理ガイド <br/>version 4.1.3</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.3/html_ja/administration/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.3/html_ja/userguide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller ユーザーガイド <br/>version 4.1.3</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.3/html_ja/userguide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.1.3/html_ja/upgrade-migration-guide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Japanese: automation controller のアップグレードおよび移行ガイド <br/>version 4.1.3</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.1.3/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
                             </div>
                         </div>
                     </a>
@@ -815,7 +1100,7 @@ h4 {
                                 <h4 class="card-title">Japanese: automation controller クイック設定ガイド <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/quickstart" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -827,7 +1112,7 @@ h4 {
                                 <h4 class="card-title">Japanese: automation controller リリースノート <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/release-notes/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -839,7 +1124,7 @@ h4 {
                                 <h4 class="card-title">Japanese: automation controller API ガイド  <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/controllerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/controllerapi/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -851,7 +1136,7 @@ h4 {
                                 <h4 class="card-title">Japanese: automation controller 管理ガイド <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/administration/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/administration/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -863,7 +1148,7 @@ h4 {
                                 <h4 class="card-title">Japanese: automation controller ユーザーガイド <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/userguide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -875,7 +1160,7 @@ h4 {
                                 <h4 class="card-title">Japanese: automation controller のアップグレードおよび移行ガイド <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1610,7 +1895,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/quickstart" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1622,7 +1907,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/quickinstall/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1634,7 +1919,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/installandreference/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1646,7 +1931,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/release-notes/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1658,7 +1943,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/towerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1670,7 +1955,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/administration/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/administration/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1682,7 +1967,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/userguide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1694,7 +1979,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1727,7 +2012,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/quickstart" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1739,7 +2024,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/quickinstall/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1751,7 +2036,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/installandreference/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1763,7 +2048,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/release-notes/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1775,7 +2060,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/towerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1787,7 +2072,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/administration/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/administration/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1799,7 +2084,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/userguide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1811,7 +2096,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1845,7 +2130,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/quickstart" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1857,7 +2142,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/quickinstall/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1869,7 +2154,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/installandreference/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1881,7 +2166,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/release-notes/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1893,7 +2178,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/towerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1905,7 +2190,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/administration/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/administration/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1917,7 +2202,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/userguide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1929,7 +2214,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1962,7 +2247,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/quickstart" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1974,7 +2259,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/quickinstall/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1986,7 +2271,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/installandreference/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1998,7 +2283,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/release-notes/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2010,7 +2295,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/towerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2022,7 +2307,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/administration/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/administration/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2034,7 +2319,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/userguide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2046,7 +2331,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2079,7 +2364,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/quickstart" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2091,7 +2376,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/quickinstall/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2103,7 +2388,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/installandreference/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2115,7 +2400,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/release-notes/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2127,7 +2412,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/towerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2139,7 +2424,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/administration/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/administration/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2151,7 +2436,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/userguide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2163,7 +2448,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2196,7 +2481,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/quickstart" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2208,7 +2493,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/quickinstall/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2220,7 +2505,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/installandreference/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2232,7 +2517,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/release-notes/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2244,7 +2529,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/towerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2256,7 +2541,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/administration/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/administration/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2268,7 +2553,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/userguide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2280,7 +2565,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2313,7 +2598,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/quickstart" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2325,7 +2610,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/quickinstall/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2337,7 +2622,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/installandreference/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2349,7 +2634,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/release-notes/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2361,7 +2646,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/towerapi/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2373,7 +2658,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/administration/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/administration/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2385,7 +2670,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/userguide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2397,7 +2682,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
                             </div>
                         </div>
                     </a>

--- a/automation-tower-japanese-translations.html
+++ b/automation-tower-japanese-translations.html
@@ -1099,7 +1099,7 @@ h4 {
                                 <h4 class="card-title">Japanese: automation controller クイック設定ガイド <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/quickstart" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1111,7 +1111,7 @@ h4 {
                                 <h4 class="card-title">Japanese: automation controller リリースノート <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/release-notes/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1123,7 +1123,7 @@ h4 {
                                 <h4 class="card-title">Japanese: automation controller API ガイド  <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/controllerapi/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/controllerapi/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1135,7 +1135,7 @@ h4 {
                                 <h4 class="card-title">Japanese: automation controller 管理ガイド <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/administration/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/administration/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1147,7 +1147,7 @@ h4 {
                                 <h4 class="card-title">Japanese: automation controller ユーザーガイド <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/userguide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1159,7 +1159,7 @@ h4 {
                                 <h4 class="card-title">Japanese: automation controller のアップグレードおよび移行ガイド <br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/automation-controller/4.0.0/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1894,7 +1894,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/quickstart" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1906,7 +1906,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/quickinstall/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1918,7 +1918,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/installandreference/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1930,7 +1930,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/release-notes/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1942,7 +1942,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/towerapi/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1954,7 +1954,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/administration/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/administration/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1966,7 +1966,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/userguide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -1978,7 +1978,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.7.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.2/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2011,7 +2011,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/quickstart" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2023,7 +2023,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/quickinstall/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2035,7 +2035,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/installandreference/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2047,7 +2047,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/release-notes/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2059,7 +2059,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/towerapi/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2071,7 +2071,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/administration/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/administration/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2083,7 +2083,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/userguide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2095,7 +2095,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.7.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.1/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2129,7 +2129,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/quickstart" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2141,7 +2141,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/quickinstall/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2153,7 +2153,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/installandreference/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2165,7 +2165,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/release-notes/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2177,7 +2177,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/towerapi/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2189,7 +2189,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/administration/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/administration/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2201,7 +2201,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/userguide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2213,7 +2213,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.7.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.7.0/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2246,7 +2246,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/quickstart" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2258,7 +2258,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/quickinstall/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2270,7 +2270,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/installandreference/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2282,7 +2282,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/release-notes/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2294,7 +2294,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/towerapi/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2306,7 +2306,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/administration/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/administration/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2318,7 +2318,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/userguide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2330,7 +2330,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.6.4</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.4/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2363,7 +2363,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/quickstart" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2375,7 +2375,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/quickinstall/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2387,7 +2387,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/installandreference/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2399,7 +2399,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/release-notes/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2411,7 +2411,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/towerapi/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2423,7 +2423,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/administration/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/administration/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2435,7 +2435,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/userguide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2447,7 +2447,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.6.3</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.3/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2480,7 +2480,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/quickstart" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2492,7 +2492,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/quickinstall/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2504,7 +2504,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/installandreference/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2516,7 +2516,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/release-notes/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2528,7 +2528,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/towerapi/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2540,7 +2540,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/administration/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/administration/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2552,7 +2552,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/userguide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2564,7 +2564,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.6.2</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.2/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2597,7 +2597,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower クイック設定ガイド <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/quickstart" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/quickstart" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2609,7 +2609,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールガイド <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/quickinstall/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/quickinstall/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2621,7 +2621,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower インストールおよびリファレンスガイド <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/installandreference/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/installandreference/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2633,7 +2633,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower リリースノート <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/release-notes/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/release-notes/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2645,7 +2645,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower API ガイド  <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/towerapi/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/towerapi/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2657,7 +2657,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower 管理ガイド <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/administration/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/administration/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2669,7 +2669,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower ユーザーガイド <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/userguide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/userguide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -2681,7 +2681,7 @@ h4 {
                                 <h4 class="card-title">Japanese: Ansible Tower のアップグレードおよび移行ガイド <br/>version 3.6.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">EOL</a>
+                            <a href="http://docs.ansible.com/ansible-tower/3.6.0/html_ja/upgrade-migration-guide/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>

--- a/automation-tower-korean-translations.html
+++ b/automation-tower-korean-translations.html
@@ -346,7 +346,6 @@ h4 {
                 </div>
 </div></div></section>
 
-
 <!-- Begin version 4.2.1 -->
     <header class="headline py-5">
         <div class="container">
@@ -439,6 +438,7 @@ h4 {
                 </div>
 </div></div></section>
 
+
 <!-- Begin version 4.2.0 -->
     <header class="headline py-5">
         <div class="container">
@@ -453,7 +453,7 @@ h4 {
     </header>
     <!-- End version 4.2.0 -->
 
-<!-- BEGIN MAIN CARDS for Korean 4.2.0 -->
+    <!-- BEGIN MAIN CARDS for Korean 4.2.0 -->
     <section class="cards pt-0">
         <div class="container">
             <div class="row">
@@ -530,6 +530,76 @@ h4 {
                     </a>
                 </div>
 </div></div></section>
+
+
+<!-- ***************************************************************************************************************************************************************************************************************************************************************************************************** -->
+
+
+    <!-- BEGIN RESOURCES SECTION - SEE .resources CSS RULE TO TOGGLE OFF -->
+    <section class="resources pt-4">
+        <div class="container">
+            <div class="row justify-content-center pb-3">
+                <div class="col col-lg-9 col-xl-7 text-center">
+                    <h2 class="mb-2">Additional Resources</h2>
+                    <p class="subhead">Vivamus magna justo, lacinia eget&nbsp;consectetur</p>
+                </div>
+            </div>
+            <div class="row">
+                <!-- BEGIN RESOURCE BLOCK 1 -->
+                <div class="col-md-4 d-flex">
+                    <div class="card border">
+                        <div class="card-body">
+                            <h4 class="card-title">Headline</h4>
+                            <a href="#" class="d-inline-block pb-2 border-bottom">
+                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
+                            </a>
+                            <a href="#" class="d-inline-block py-2 border-bottom">
+                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
+                            </a>
+                            <a href="#" class="d-inline-block pt-2">
+                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
+                            </a>
+                          </div>
+                    </div>
+                </div>
+                <!-- BEGIN RESOURCE BLOCK 2 -->
+                <div class="col-md-4 d-flex">
+                    <div class="card border">
+                        <div class="card-body">
+                            <h4 class="card-title">Headline</h4>
+                            <a href="#" class="d-inline-block pb-2 border-bottom">
+                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
+                            </a>
+                            <a href="#" class="d-inline-block py-2 border-bottom">
+                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
+                            </a>
+                            <a href="#" class="d-inline-block pt-2">
+                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
+                            </a>
+                          </div>
+                    </div>
+                </div>
+                <!-- BEGIN RESOURCE BLOCK 3 -->
+                <div class="col-md-4 d-flex">
+                    <div class="card border">
+                        <div class="card-body">
+                            <h4 class="card-title">Headline</h4>
+                            <a href="#" class="d-inline-block pb-2 border-bottom">
+                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
+                            </a>
+                            <a href="#" class="d-inline-block py-2 border-bottom">
+                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
+                            </a>
+                            <a href="#" class="d-inline-block pt-2">
+                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
+                            </a>
+                          </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <!-- END RESOURCES SECTION - SEE '.resources' CSS RULE TO TOGGLE OFF -->
 
     <!-- BEGIN FOOTER -->
     <section class="footer py-0">

--- a/automation-tower-korean-translations.html
+++ b/automation-tower-korean-translations.html
@@ -439,6 +439,20 @@ h4 {
                 </div>
 </div></div></section>
 
+<!-- Begin version 4.2.0 -->
+    <header class="headline py-5">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col text-center">
+                    <a id="4.2.0">
+                    <p class="subhead">automation controller 4.2.0</p>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </header>
+    <!-- End version 4.2.0 -->
+
 <!-- BEGIN MAIN CARDS for Korean 4.2.0 -->
     <section class="cards pt-0">
         <div class="container">

--- a/automation-tower-korean-translations.html
+++ b/automation-tower-korean-translations.html
@@ -242,6 +242,9 @@ h4 {
                         <a class="nav-link" href="#4.3.0">4.3.0</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="#4.2.1">4.2.1</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="#4.2.0">4.2.0</a>
                     </li>
                 </ul>
@@ -344,21 +347,99 @@ h4 {
 </div></div></section>
 
 
-<!-- Begin version 4.2.0 -->
+<!-- Begin version 4.2.1 -->
     <header class="headline py-5">
         <div class="container">
             <div class="row justify-content-center">
                 <div class="col text-center">
-                    <a id="4.2.0">
-                    <p class="subhead">automation controller 4.2.0</p>
+                    <a id="4.2.1">
+                    <p class="subhead">automation controller 4.2.1</p>
                     </a>
                 </div>
             </div>
         </div>
     </header>
-    <!-- End version 4.2.0 -->
+    <!-- End version 4.2.1 -->
 
-    <!-- BEGIN MAIN CARDS for Korean 4.2.0 -->
+    <!-- BEGIN MAIN CARDS for Korean 4.2.1 -->
+    <section class="cards pt-0">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ko/quickstart">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Korean: automation controller 퀵스타트 가이드 <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ko/quickstart" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ko/release-notes/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Korean: automation controller 릴리스  노트 <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ko/release-notes/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ko/controllerapi/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Korean: automation controller API 가이드  <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ko/controllerapi/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ko/administration/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Korean: automation controller 관리 가이드 <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ko/administration/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ko/userguide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Korean: automation controller 사용자 가이드 <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ko/userguide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ko/upgrade-migration-guide/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Korean: automation controller 업그레이드 마이그레이션 가이드 <br/>version 4.2.1</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="http://docs.ansible.com/automation-controller/4.2.1/html_ko/upgrade-migration-guide/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+</div></div></section>
+
+<!-- BEGIN MAIN CARDS for Korean 4.2.0 -->
     <section class="cards pt-0">
         <div class="container">
             <div class="row">
@@ -435,76 +516,6 @@ h4 {
                     </a>
                 </div>
 </div></div></section>
-
-
-<!-- ***************************************************************************************************************************************************************************************************************************************************************************************************** -->
-
-
-    <!-- BEGIN RESOURCES SECTION - SEE .resources CSS RULE TO TOGGLE OFF -->
-    <section class="resources pt-4">
-        <div class="container">
-            <div class="row justify-content-center pb-3">
-                <div class="col col-lg-9 col-xl-7 text-center">
-                    <h2 class="mb-2">Additional Resources</h2>
-                    <p class="subhead">Vivamus magna justo, lacinia eget&nbsp;consectetur</p>
-                </div>
-            </div>
-            <div class="row">
-                <!-- BEGIN RESOURCE BLOCK 1 -->
-                <div class="col-md-4 d-flex">
-                    <div class="card border">
-                        <div class="card-body">
-                            <h4 class="card-title">Headline</h4>
-                            <a href="#" class="d-inline-block pb-2 border-bottom">
-                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
-                            </a>
-                            <a href="#" class="d-inline-block py-2 border-bottom">
-                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
-                            </a>
-                            <a href="#" class="d-inline-block pt-2">
-                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
-                            </a>
-                          </div>
-                    </div>
-                </div>
-                <!-- BEGIN RESOURCE BLOCK 2 -->
-                <div class="col-md-4 d-flex">
-                    <div class="card border">
-                        <div class="card-body">
-                            <h4 class="card-title">Headline</h4>
-                            <a href="#" class="d-inline-block pb-2 border-bottom">
-                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
-                            </a>
-                            <a href="#" class="d-inline-block py-2 border-bottom">
-                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
-                            </a>
-                            <a href="#" class="d-inline-block pt-2">
-                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
-                            </a>
-                          </div>
-                    </div>
-                </div>
-                <!-- BEGIN RESOURCE BLOCK 3 -->
-                <div class="col-md-4 d-flex">
-                    <div class="card border">
-                        <div class="card-body">
-                            <h4 class="card-title">Headline</h4>
-                            <a href="#" class="d-inline-block pb-2 border-bottom">
-                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
-                            </a>
-                            <a href="#" class="d-inline-block py-2 border-bottom">
-                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
-                            </a>
-                            <a href="#" class="d-inline-block pt-2">
-                                Lorem ipsum dolor sit amet consectetur adipiscing elit in sit...
-                            </a>
-                          </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-    <!-- END RESOURCES SECTION - SEE '.resources' CSS RULE TO TOGGLE OFF -->
 
     <!-- BEGIN FOOTER -->
     <section class="footer py-0">

--- a/automation-tower-prior-versions.html
+++ b/automation-tower-prior-versions.html
@@ -267,6 +267,18 @@ h4 {
                     </a>
                 </div>
                 <div class="col-md-6 col-lg-4">
+                    <a href="https://docs.ansible.com/automation-controller/4.1.4/html/">
+                        <div class="card border">
+                            <div class="card-body">
+                                <h4 class="card-title">Automation: Controller,<br/>version 4.1.4</h4>
+                            </div>
+                             <div class="card-footer">
+                            <a href="https://docs.ansible.com/automation-controller/4.1.4/html/" class="btn btn-outline-black">Supported</a>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-md-6 col-lg-4">
                     <a href="https://docs.ansible.com/automation-controller/4.1.3/html/">
                         <div class="card border">
                             <div class="card-body">
@@ -321,7 +333,7 @@ h4 {
                                 <h4 class="card-title">Automation: Controller,<br/>version 4.0.1</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="https://docs.ansible.com/automation-controller/4.0.1/html/" class="btn btn-outline-black">Supported</a>
+                            <a href="https://docs.ansible.com/automation-controller/4.0.1/html/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>
@@ -333,7 +345,7 @@ h4 {
                                 <h4 class="card-title">Automation: Controller,<br/>version 4.0.0</h4>
                             </div>
                              <div class="card-footer">
-                            <a href="https://docs.ansible.com/automation-controller/4.0.0/html/" class="btn btn-outline-black">Supported</a>
+                            <a href="https://docs.ansible.com/automation-controller/4.0.0/html/" class="btn btn-outline-black">End of Maintenance Support - EOL</a>
                             </div>
                         </div>
                     </a>


### PR DESCRIPTION
Adds the following:
- 4.1.4 (English, Japanese, Chinese)
- 4.2.1 (Japanese, Chinese, Korean)
- 4.1.3 (Japanese, Chinese)

Marked the following versions as EOL'd:
- 4.0 and 4.0.1 where applicable
- 3.7.x and older where applicable

See rendered content:
- http://docs.testing.ansible.com/automation-tower-prior-versions.html
- http://docs.testing.ansible.com/automation-tower-japanese-translations.html
- http://docs.testing.ansible.com/automation-tower-chinese-translations.html
- http://docs.testing.ansible.com/automation-tower-korean-translations.html