### PR TITLE
Action to build package docs

### DIFF
--- a/.github/workflows/publish-package-docs.yaml
+++ b/.github/workflows/publish-package-docs.yaml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   build-package-docs:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       PACKAGE_VERSION: "${{ github.event.inputs.package_version }}"
       LANGUAGE: ${{ github.event.inputs.language}}

--- a/.github/workflows/publish-package-docs.yaml
+++ b/.github/workflows/publish-package-docs.yaml
@@ -34,7 +34,7 @@ on:
         - '2.10'
       latest_symlink:
         type: boolean
-        description: 'Add latest symlink?'
+        description: 'Add latest symlink'
         required: true
 
 jobs:
@@ -91,4 +91,11 @@ jobs:
         run: |
           pushd build-directory/docs/docsite
           make webdocs ANSIBLE_VERSION="${COLLECTION_LIST}"
+          popd
+
+      - name: Create latest symlink
+        if: ${{ github.event.inputs.latest_symlink == 'true' }}
+        run: |
+          pushd build-directory/docs/docsite
+          ln -s ${VERSION} _build/latest
           popd

--- a/.github/workflows/publish-package-docs.yaml
+++ b/.github/workflows/publish-package-docs.yaml
@@ -51,11 +51,6 @@ jobs:
           ref: ${{ github.event.inputs.github_branch }}
           path: build-directory
 
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.10'
-
       - name: Output Python info
         run: python --version --version && which python
 

--- a/.github/workflows/publish-package-docs.yaml
+++ b/.github/workflows/publish-package-docs.yaml
@@ -1,0 +1,94 @@
+name: Ansible package docs build
+on:
+  workflow_dispatch:
+    inputs:
+      github_fork:
+        description: 'GitHub Fork'
+        required: true
+        default: 'ansible'
+      github_branch:
+        description: 'GitHub Branch'
+        required: true
+        default: 'devel'
+      language:
+        type: choice
+        description: 'Language'
+        required: true
+        default: 'english'
+        options:
+        - 'english'
+        - 'japanese'
+      package_version:
+        type: choice
+        description: 'Ansible Version'
+        required: true
+        default: 'devel'
+        options:
+        - 'devel'
+        - '8'
+        - '7'
+        - '6'
+        - '5'
+        - '4'
+        - '3'
+        - '2.10'
+      latest_symlink:
+        type: boolean
+        description: 'Add latest symlink?'
+        required: true
+
+jobs:
+  build-package-docs:
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_VERSION: "${{ github.event.inputs.package_version }}"
+      LANGUAGE: ${{ github.event.inputs.language}}
+    steps:
+      - name: Checkout Ansible
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.inputs.github_fork }}/ansible
+          ref: ${{ github.event.inputs.github_branch }}
+          path: build-directory
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Output Python info
+        run: python --version --version && which python
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools six wheel
+
+      - name: Install project requirements
+        run: |
+          pushd build-directory
+          python -m pip install -r requirements.txt
+          python -m pip install -r docs/docsite/requirements.txt
+          popd
+
+      - name: Set the COLLECTION_LIST variable
+        run: |
+          if [ ${PACKAGE_VERSION} == "devel" ]; then
+            echo COLLECTION_LIST="" >> $GITHUB_ENV
+          else
+            echo COLLECTION_LIST="${PACKAGE_VERSION}" >> $GITHUB_ENV
+          fi
+
+      - name: Set the VERSION variable
+        run: |
+          if [ ${LANGUAGE} == "english" ]; then
+            echo VERSION="${PACKAGE_VERSION}" >> $GITHUB_ENV
+          elif [ ${LANGUAGE} == "japanese" ]; then
+            echo VERSION="${PACKAGE_VERSION}_ja" >> $GITHUB_ENV
+          fi
+
+      - name: Build the docs
+        run: |
+          pushd build-directory/docs/docsite
+          make webdocs ANSIBLE_VERSION="${COLLECTION_LIST}"
+          popd


### PR DESCRIPTION
Resolves issue #131 and relates to: https://github.com/ansible-community/community-topics/issues/174

Here's a screen of the inputs for kicking off the publishing workflow: 

![image](https://user-images.githubusercontent.com/32749632/210985557-fca10f9d-9611-43cd-a2f2-26ce1f0f8129.png)

There are some workflow runs on my fork at: https://github.com/oraNod/docsite/actions/workflows/publish-package-docs.yaml