### PR TITLE
Separate requirements steps

### DIFF
--- a/.github/workflows/publish-package-docs.yaml
+++ b/.github/workflows/publish-package-docs.yaml
@@ -59,7 +59,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install setuptools six wheel
 
-      - name: Install project requirements
+      - name: Install ansible-core requirements
         run: python -m pip install -r requirements.txt
         working-directory: build-directory
 

--- a/.github/workflows/publish-package-docs.yaml
+++ b/.github/workflows/publish-package-docs.yaml
@@ -60,11 +60,12 @@ jobs:
           python -m pip install setuptools six wheel
 
       - name: Install project requirements
-        run: |
-          pushd build-directory
-          python -m pip install -r requirements.txt
-          python -m pip install -r docs/docsite/requirements.txt
-          popd
+        run: python -m pip install -r requirements.txt
+        working-directory: build-directory
+
+      - name: Install docsite requirements
+        run: python -m pip install -r docs/docsite/requirements.txt
+        working-directory: build-directory
 
       - name: Set collection list
         run: |

--- a/.github/workflows/publish-package-docs.yaml
+++ b/.github/workflows/publish-package-docs.yaml
@@ -64,7 +64,7 @@ jobs:
         working-directory: build-directory
 
       - name: Install docsite requirements
-        run: python -m pip install -r docs/docsite/requirements.txt
+        run: python -m pip install -r test/sanity/code-smell/docs-build.requirements.txt
         working-directory: build-directory
 
       - name: Set collection list


### PR DESCRIPTION
Update the workflow to use working-directory for requirements and create separate steps for project and docsite requirements.