### PR TITLE
ansible-docsite-personas.md: re-define the page based on feedback collected so far

### DIFF
--- a/personas/ansible-docsite-personas.md
+++ b/personas/ansible-docsite-personas.md
@@ -4,6 +4,8 @@ Personas represent various humans who are all on different automation journeys w
 
 We use personas to ensure Ansible community users can find help when and where they need it. If the right support is there, users are much more likely to succeed with their goals. This leads to higher levels of adoption and a more vibrant, stronger community.
 
+The practical goal of this document is to define a layout for a new `docs.ansible.com` homepage based on the following docsite personas.
+
 ## Novice
 
 <img src="https://i.imgur.com/GMilRTB.png" alt="Person using a computer" width="100"/>
@@ -24,21 +26,11 @@ I write automation content like playbooks and roles. When writing playbooks and 
 * **Attitude:** Does not like out of date, incomplete, or missing documentation.
 * **Knowledge:** Proficient. I am at home on the command line and enjoy technical challenges.
 
-## Operations
-
-<img src="https://i.imgur.com/0yGl5p2.png" alt="Person using a computer" width="100"/>
-
-I'm all about the uptime. I provision and maintain AWX or Galaxy NG deployments that provide collections, roles, EEs, job templates, and so on across my organization. I also control which EEs to use with automation jobs, where they run, and who can execute them.
-
-* **Needs:** Planning and sizing requirements, installation, scaling physical and virtual infrastructure, upgrades, monitoring and troubleshooting.
-* **Attitude:** Wants to guarantee availability and identify and remediate issues as quickly as possible.
-* **Knowledge:** Expert knowledge of IT platforms, networking, and systems.
-
 ## Developer
 
 <img src="https://i.imgur.com/QufXcjw.png" alt="Person using a computer" width="100"/>
 
-I write Ansible plugins and modules in Python or other programming languages.
+I write or want to get started writing Ansible plugins and modules in Python or other programming languages.
 
 * **Needs:** Understand programmatic options and their expected behaviour.
 * **Attitude:** Technically curious and prefers verbosity.
@@ -48,11 +40,11 @@ I write Ansible plugins and modules in Python or other programming languages.
 
 <img src="https://i.imgur.com/GY18SFy.png" alt="Person using a computer" width="100"/>
 
-I work with the community to maintain one or more collections as part of the Ansible package. I also work on community tooling such as Antsibull or other projects.
+I work with the community to maintain one or more collections as part of the Ansible package or I want to create my own collection, set everything up and running and maintain it. I might also be interested in working on community tooling such as Antsibull or other projects.
 
-* **Needs:** Clear path for getting collections included in the Ansible package. Guidance on lifecycles and maintenance guidelines.
+* **Needs:** Clear path for creating collections from scratch and optionally getting them included in the Ansible package. Guidance on lifecycles and maintenance guidelines.
 * **Attitude:** Often busy with another more primary role.
-* **Knowledge:** Proficient to expert IT skills with project management.
+* **Knowledge:** Basic to expert IT skills with project management.
 
 ## Community member/evangelist
 
@@ -60,6 +52,10 @@ I work with the community to maintain one or more collections as part of the Ans
 
 I participate in the Ansible ecosystem community to learn and share my Ansible knowledge.
 
-* **Needs:** Guidance on where and how I can contribute as a coder or non-coder for Ansible projects.
+* **Needs:** Guidance on where and how I can contribute as a non-coder for Ansible projects.
 * **Attitude:** Enthusiastic about Ansible.
 * **Knowledge:** Intermediate or above expertise in one or more parts of Ansible.
+
+## Other links on the top page
+
+* A quick link for advanced readers so that they can get a page that lists everything which is similar to the current ecosystem page but not with those big spacy boxes as they take up too much room.


### PR DESCRIPTION
Based on feedback collected in https://github.com/ansible-community/community-topics/issues/175

In particular:
- Haven't we [agreed](https://github.com/ansible-community/community-topics/issues/175#issuecomment-1404755361) not to treat `Operators` as a separate category but rather a sub-category of users? See the suggested changes
- Based on Sandra's [comment](https://github.com/ansible-community/community-topics/issues/175#issuecomment-1400812701) (+1 from me), we can include the quick-link for experts. See the suggested changes