### PR TITLE
Update navigator docs url

### DIFF
--- a/ecosystem.html
+++ b/ecosystem.html
@@ -359,7 +359,7 @@
             </a>
           </div>
           <div class="col-md-6 col-lg-4">
-            <a href="https://ansible-navigator.readthedocs.io/en/latest/">
+            <a href="https://ansible-navigator.readthedocs.io/">
               <div class="card border">
                 <div class="card-body">
                   <h4 class="card-title">Ansible Navigator</h4>
@@ -370,7 +370,7 @@
                 </div>
                 <div class="card-footer">
                   <a
-                    href="https://ansible-navigator.readthedocs.io/en/latest/"
+                    href="https://ansible-navigator.readthedocs.io/"
                     class="btn btn-outline-black"
                     >Visit the documentation</a
                   >


### PR DESCRIPTION
Navigator docs url needs to be changed after switch to mkdocs.

https://ansible-navigator.readthedocs.io/en/latest is 404