### PR TITLE
Point to RTD for Ansible Sign documentation

### DIFF
--- a/ecosystem.html
+++ b/ecosystem.html
@@ -333,7 +333,7 @@
       <div class="width-6-12 width-12-12-m">
         <h5>Ansible Sign</h5>
         <p>Ansible Sign is a utility for signing and verifying Ansible content.</p>
-        <a class="btn" href="https://ansible.github.io/ansible-sign/" role="button">
+        <a class="btn" href="https://ansible-sign.readthedocs.io/en/latest/" role="button">
           Ansible Sign documentation
         </a>
       </div>


### PR DESCRIPTION
This PR migrates Ansible Sign documentation links on the ecosystem page to RTD.