### PR TITLE
update awx operator docs home

### DIFF
--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -28,7 +28,7 @@ awx_operator:
   name: AWX Operator
   description: Ansible AWX Operator offers built-in intelligence and operational best practices for deploying on Kubernetes environments.
   docs:
-    home: "https://github.com/ansible/awx-operator"
+    home: "https://ansible.readthedocs.io/projects/awx-operator/"
 builder:
   name: Ansible Builder
   description: Ansible Builder lets you create Execution Environments, which are container images that act as Ansible control nodes.


### PR DESCRIPTION
Change the url for the AWX Operator docs to point to https://ansible.readthedocs.io/projects/awx-operator/en/latest/