### PR TITLE
Update ecosystem.yaml to remove pinakes

### DIFF
--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -90,11 +90,6 @@ navigator:
   description: Ansible Navigator is a command-line tool for creating, reviewing, and troubleshooting Ansible content.
   docs:
     home: "https://ansible.readthedocs.io/projects/navigator/"
-pinakes:
-  name: Pinakes
-  description: Pinakes lets you make Ansible job templates and workflows available to business users with an added layer of governance.
-  docs:
-    home: "https://github.com/ansible/pinakes"
 pylibssh:
   name: Ansible Pylibssh
   description: Ansible Pylibssh provides Python bindings for Ansible with the libssh project.


### PR DESCRIPTION
Remove pinakes from the current ecosystem

It has not been updated in 10 months, its not in current development, and not planned to be developed further. In addition while the parts that work are good, it still has a good handful of non working features, it is still in tech preview. 

While the Repo should stay, we should likely take it off the current Ecosystem docsite.