### PR TITLE
Issue 190 Fix link to AWX docs in ecosystem page

### DIFF
--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -23,7 +23,7 @@ awx:
   name: Ansible AWX
   description: AWX provides a web-based user interface, REST API, and task engine built on top of Ansible.
   docs:
-    home: "https://github.com/ansible/awx"
+    home: "https://ansible.readthedocs.io/projects/awx/"
 awx_operator:
   name: AWX Operator
   description: Ansible AWX Operator offers built-in intelligence and operational best practices for deploying on Kubernetes environments.


### PR DESCRIPTION
Fix the link to AWX docs from the ecosystem page (https://docs.ansible.com/ecosystem.html).
Fixes #190 