### PR TITLE
Replaced IRC with the Forum on the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains source templates and a Python utility to generate HTML 
 
 Join the Ansible community and help us build a better user experience for the docsite.
 
-We talk about Ansible documentation on Matrix at [#docs:ansible.im](https://matrix.to/#/#docs:ansible.im) and on Libera IRC at ``#ansible-docs``.
+We talk about Ansible documentation on Matrix at [#docs:ansible.im](https://matrix.to/#/#docs:ansible.im) and on the [Ansible Community Forum] (https://forum.ansible.com/tag/documentation).
 You're welcome to join us, chat about the Ansible docs, and share your thoughts.
 
 The Ansible community docs group (the DaWGs) meets every Tuesday (see [the Ansible calendar](https://github.com/ansible/community/blob/main/meetings/README.md)) and welcomes additions to our [weekly agenda items](https://github.com/ansible/community/issues/678) - scroll down to find the upcoming agenda and add a comment to include your topic.


### PR DESCRIPTION
IRC on libra chat has been discontinued and now we are redirecting community to Forum.