### PR TITLE
redirect automation to redhat.com

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -13,6 +13,10 @@ RedirectMatch permanent "^/((?!index|404|automation.*|ansible_community|collecti
 RedirectMatch permanent "/galaxy.html" "/ecosystem.html"
 RedirectMatch permanent "/lint.html" "/ecosystem.html"
 
+# Redirect the automation page to the platform page
+
+RedirectMatch permanent "/automation.html" "/platform.html"
+
 # Redirect so docs.ansible.com/ansible-core/ and docs.ansible.com/ansible/ dont show an Index of page anymore
 
 RedirectMatch permanent "^/ansible-core(|/|/index.html)$" "/ansible-core/devel/"


### PR DESCRIPTION
This PR redirects the old "automation.html" page in a consistent way with redirects to redhat.com urls on the community website: https://www.redhat.com/en/technologies/management/ansible