### PR TITLE
masthead consistency with community website

### DIFF
--- a/sass/_docbar.scss
+++ b/sass/_docbar.scss
@@ -9,5 +9,10 @@
 	}
     .nav-link {
         text-align: center;
+        color: $white;
+		font-size: 1rem;
+		&:hover {
+		  color: $light-grey;
+		}
     }
 }

--- a/sass/_nav.scss
+++ b/sass/_nav.scss
@@ -1,5 +1,5 @@
 nav {
-	background: $black;
+	background: $pool;
 	.navbar-toggler {
 		color: $white;
 		outline: none;
@@ -32,21 +32,21 @@ nav {
 		margin-top: 0.5rem;
 	}
 	.navbar-brand {
-		color: $white;
+		color: $black;
 		font-size: 1.2rem;
 		padding-right: 4px;
 		&:hover {
-		  color: $pool;
+		  color: $white;
 		}
 	}
 	.nav-item {
         padding: 1px 4px;
 	}
 	.nav-link {
-		color: $white;
+		color: $black;
 		font-size: 1rem;
 		&:hover {
-		  color: $pool;
+		  color: $white;
 		}
 	}
 	@media screen and (max-width: 990px) {

--- a/static/images/community_logo_black.svg
+++ b/static/images/community_logo_black.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" width="300px" height="300px" id="community-logo-black" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<title>Ansible-Mark-RGB</title>
+<path d="M259.8,152.9c0,59-47.8,106.8-106.8,106.8c-59,0-106.8-47.8-106.8-106.8S94,46.1,153,46.1c0,0,0,0,0,0
+	C212,46.1,259.8,93.9,259.8,152.9C259.8,152.9,259.8,152.9,259.8,152.9"/>
+<path class="st0" d="M154.8,112.9l27.6,68.2l-41.7-32.9L154.8,112.9z M203.9,196.8L161.4,94.5c-1-2.8-3.7-4.6-6.6-4.5
+	c-3-0.1-5.7,1.7-6.8,4.5l-46.7,112.2h16l18.5-46.3l55.1,44.5c2.2,1.8,3.8,2.6,5.9,2.6c4.2,0.1,7.7-3.2,7.8-7.4c0-0.1,0-0.1,0-0.2
+	C204.6,198.9,204.3,197.8,203.9,196.8"/>
+</svg>

--- a/templates/_nav.html
+++ b/templates/_nav.html
@@ -1,29 +1,9 @@
 <nav class="navbar navbar-expand-md p-1">
   <div class="container">
     <a href="{{ links.index }}">
-      <span class="navbar-brand d-flex justify-content-center">
-        <svg version="1.1"
-          id="Layer_1"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-          x="0px"
-          y="0px"
-          width="28"
-          height="28"
-          viewBox="0 0 28 28"
-          style="enable-background: new 0 0 28 28"
-          xml:space="preserve"
-          class="mr-1">
-          <style type="text/css">
-            .ansHeader {
-              fill: #ffffff;
-            }
-          </style>
-          <circle class="ansHeader" cx="14" cy="14" r="13.5" />
-          <path
-            d="M20.4,19.3L15,6.4c-0.2-0.4-0.5-0.6-0.8-0.6c-0.4,0-0.7,0.2-0.9,0.6L7.5,20.6h2l2.3-5.8l7,5.6c0.3,0.2,0.5,0.3,0.7,0.3c0.5,0,1-0.4,1-1C20.5,19.6,20.4,19.5,20.4,19.3z M14.2,8.7l3.5,8.6l-5.3-4.1L14.2,8.7z"/>
-        </svg>
-        Ansible documentation
+      <span class="navbar-brand d-flex align-items-center">
+        <img src="static/images/community_logo_black.svg" width="50px" height="50px" alt="Ansible community logo"/>
+        <span class="ml-2">Ansible documentation</span>
       </span>
     </a>
     <button
@@ -43,19 +23,10 @@
     <div class="collapse navbar-collapse" id="main-menu">
       <ul class="navbar-nav ml-auto">
         <li class="nav-item">
-          <a class="nav-link" href="https://www.ansible.com/products/automation-platform">Products</a>
+          <a class="nav-link" href="https://www.ansible.com/blog/">Blog</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="https://www.ansible.com/blog">Blog</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="https://www.ansible.com/community">Community</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="https://www.ansible.com/resources/webinars-training">Webinars and training</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="https://www.redhat.com/en/technologies/management/ansible/try-it">Try it now</a>
+          <a class="nav-link" href="https://forum.ansible.com/">Ansible community forum</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Resolves: https://github.com/ansible/docsite/issues/200

Note that the masthead does not contain the same "documentation" link as on the community website, given this is on "docs.ansible.com". Maybe we could move the platform link there and point to https://www.redhat.com/en/technologies/management/ansible - However I would prefer doing that in a follow up.

Likewise we should update the entries in the docbar below the masthead in a follow up.