### PR TITLE
Add specific titles for each page

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,3 +1,4 @@
+{% set page_title = "Not found" %}
 {% extends "_base.html" %} {% block body %}
 <section class="container">
   <div class="row-fluid-wrapper row-depth-1 row-number-3">

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{{ base.site_title }}</title>
+    <title>{{ (page_title ~ " | " if page_title is defined else "") ~ base.site_title }}</title>
     <meta name="description" content="{{ base.site_description }}" />
     <meta name="author" content="{{ base.site_author }}" />
     <link rel="stylesheet"

--- a/templates/ansible-prior-versions.html
+++ b/templates/ansible-prior-versions.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.community.archive.title %}
 {% extends "_base.html" %} {% block body %}
 <div class="container">
   <div class="full-width-bg component">

--- a/templates/ansible_community.html
+++ b/templates/ansible_community.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.community_docs.title %}
 {% extends "_base.html" %} {% block body %}
 <div class="container">
   <div class="full-width-bg component">

--- a/templates/automation-tower-chinese-translations.html
+++ b/templates/automation-tower-chinese-translations.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.controller.tower_zh.title %}
 {% extends "_base.html" %}
 {% block body %}
 <div class="container">

--- a/templates/automation-tower-japanese-translations.html
+++ b/templates/automation-tower-japanese-translations.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.controller.tower_ja.title %}
 {% extends "_base.html" %}
 {% block body %}
 <div class="container">

--- a/templates/automation-tower-korean-translations.html
+++ b/templates/automation-tower-korean-translations.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.controller.tower_ko.title %}
 {% extends "_base.html" %}
 {% block body %}
 <div class="container">

--- a/templates/automation-tower-prior-versions.html
+++ b/templates/automation-tower-prior-versions.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.controller.archive.title %}
 {% extends "_base.html" %} {% block body %}
 <div class="container">
   <div class="full-width-bg component">

--- a/templates/community.html
+++ b/templates/community.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.community.title %}
 {% extends "_base.html" %} {% block body %}
 <div class="container">
   <div class="full-width-bg component">

--- a/templates/core-translated-ja.html
+++ b/templates/core-translated-ja.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.core.core_ja.title %}
 {% extends "_base.html" %}
 {% block body %}
 <div class="container">

--- a/templates/core.html
+++ b/templates/core.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.core.title %}
 {% extends "_base.html" %}
 {% block body %}
 <div class="container">

--- a/templates/developers.html
+++ b/templates/developers.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.developers.title %}
 {% extends "_base.html" %} {% block body %}
 <div class="container">
   <div class="full-width-bg component">

--- a/templates/ecosystem.html
+++ b/templates/ecosystem.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.ecosystem.title %}
 {% extends "_base.html" %}
 {% block body %}
 <div class="container">

--- a/templates/maintainers.html
+++ b/templates/maintainers.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.maintainers.title %}
 {% extends "_base.html" %} {% block body %}
 <div class="container">
   <div class="full-width-bg component">

--- a/templates/platform.html
+++ b/templates/platform.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.platform.title %}
 {% extends "_base.html" %} {% block body %}
 <div class="container">
     <div class="full-width-bg component">

--- a/templates/users.html
+++ b/templates/users.html
@@ -1,3 +1,4 @@
+{% set page_title = pages.users.title %}
 {% extends "_base.html" %} {% block body %}
 <div class="container">
   <div class="full-width-bg component">


### PR DESCRIPTION
This makes it much easier to see what's going on with multiple tabs open.

For example:

Before:

> Ansible Documentation

After:

> Users | Ansible Documentation

![New title](https://github.com/ansible/docsite/assets/9920591/0cec7a68-55d1-4f40-be46-7465e6433ead)
