### PR TITLE
fix pylibssh naming

### DIFF
--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -86,8 +86,8 @@ navigator:
   docs:
     home: "https://ansible.readthedocs.io/projects/navigator/"
 pylibssh:
-  name: pylibssh
-  description: pylibssh provides Python bindings for Ansible with the libssh project.
+  name: ansible-pylibssh
+  description: ansible-pylibssh provides Python bindings for Ansible with the libssh project.
   docs:
     home: "https://ansible-pylibssh.readthedocs.io/en/latest/"
 receptor:

--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -86,8 +86,8 @@ navigator:
   docs:
     home: "https://ansible.readthedocs.io/projects/navigator/"
 pylibssh:
-  name: Ansible Pylibssh
-  description: Ansible Pylibssh provides Python bindings for Ansible with the libssh project.
+  name: pylibssh
+  description: pylibssh provides Python bindings for Ansible with the libssh project.
   docs:
     home: "https://ansible-pylibssh.readthedocs.io/en/latest/"
 receptor:


### PR DESCRIPTION
This PR changes "Ansible Pylibssh" to "pylibssh" on the ecosystem page.