### PR TITLE
prepend the base url to site assets

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -17,7 +17,7 @@
             data-hs-cos-type="rich_text">
             <div style="text-align: center">
               <img
-                src="static/images/cow.png"
+                src="{{ base.base_url }}static/images/cow.png"
                 class="img-fluid align-self-end"
                 alt="cowsay404"/>
             </div>

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -13,9 +13,9 @@
       href="https://use.fontawesome.com/releases/v5.1.0/css/all.css"
       integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt"
       crossorigin="anonymous"/>
-    <link rel="stylesheet" href="static/css/styles.min.css"/>
-    <link rel="stylesheet" href="static/css/main.css">
-    <link rel="stylesheet" href="static/css/redhat-footer.css">
+    <link rel="stylesheet" href="{{ base.base_url }}static/css/styles.min.css"/>
+    <link rel="stylesheet" href="{{ base.base_url }}static/css/main.css">
+    <link rel="stylesheet" href="{{ base.base_url }}static/css/redhat-footer.css">
   </head>
   <body>
     {% include "_nav.html" %}

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -7,6 +7,6 @@
     Sponsored by
   </span>
   <span class="redhat-logo">
-    <a href="https://www.redhat.com/" target="_blank"><img src="static/images/redhat_reversed.svg" alt="Red Hat logo"></a>
+    <a href="https://www.redhat.com/" target="_blank"><img src="{{ base.base_url }}static/images/redhat_reversed.svg" alt="Red Hat logo"></a>
   </span>
 </div>

--- a/templates/_scripts.html
+++ b/templates/_scripts.html
@@ -1,4 +1,4 @@
-<script src="static/js/iframeResizer.min.js" type="javascript"></script>
+<script src="{{ base.base_url }}static/js/iframeResizer.min.js" type="javascript"></script>
 <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" crossorigin="anonymous"></script>
 <script src="https://www.ansible.com/hubfs/js/scripts.min.js"></script>
 <script src="https://www.redhat.com/dtm.js"></script>

--- a/templates/ansible-prior-versions.html
+++ b/templates/ansible-prior-versions.html
@@ -5,7 +5,7 @@
   <div class="full-width-bg component">
     <div class="grid-wrapper">
       <div class="width-3-12 width-12-12-m">
-        <img class="page-logo" src="static/images/community_logo.svg">
+        <img class="page-logo" src="{{ base.base_url }}static/images/community_logo.svg">
       </div>
       <div class="width-9-12 width-12-12-m">
         <div class="page-title">

--- a/templates/ansible_community.html
+++ b/templates/ansible_community.html
@@ -5,7 +5,7 @@
   <div class="full-width-bg component">
     <div class="grid-wrapper">
       <div class="width-3-12 width-12-12-m">
-        <img class="page-logo" src="static/images/community_logo.svg">
+        <img class="page-logo" src="{{ base.base_url }}static/images/community_logo.svg">
       </div>
       <div class="width-9-12 width-12-12-m">
         <div class="page-title">

--- a/templates/community.html
+++ b/templates/community.html
@@ -5,7 +5,7 @@
   <div class="full-width-bg component">
     <div class="grid-wrapper">
       <div class="width-3-12 width-12-12-m">
-        <img class="page-logo" src="static/images/community_logo.svg">
+        <img class="page-logo" src="{{ base.base_url }}static/images/community_logo.svg">
       </div>
       <div class="width-9-12 width-12-12-m">
         <div class="page-title">

--- a/templates/core-translated-ja.html
+++ b/templates/core-translated-ja.html
@@ -6,7 +6,7 @@
   <div class="full-width-bg component">
     <div class="grid-wrapper">
       <div class="width-3-12 width-12-12-m">
-        <img class="page-logo" src="static/images/community_logo.svg">
+        <img class="page-logo" src="{{ base.base_url }}static/images/community_logo.svg">
       </div>
       <div class="width-9-12 width-12-12-m">
         <div class="page-title">

--- a/templates/core.html
+++ b/templates/core.html
@@ -6,7 +6,7 @@
   <div class="full-width-bg component">
     <div class="grid-wrapper">
       <div class="width-3-12 width-12-12-m">
-        <img class="page-logo" src="static/images/community_logo.svg">
+        <img class="page-logo" src="{{ base.base_url }}static/images/community_logo.svg">
       </div>
       <div class="width-9-12 width-12-12-m">
         <div class="page-title">

--- a/templates/ecosystem.html
+++ b/templates/ecosystem.html
@@ -6,7 +6,7 @@
   <div class="full-width-bg component">
     <div class="grid-wrapper">
       <div class="width-3-12 width-12-12-m">
-        <img class="page-logo" src="static/images/community_logo.svg">
+        <img class="page-logo" src="{{ base.base_url }}static/images/community_logo.svg">
       </div>
       <div class="width-9-12 width-12-12-m">
         <div class="page-title">


### PR DESCRIPTION
This change prevents relative links to assets such as css files that can result in issues with site crawlers.