### PR TITLE
update robots.txt to disallow old urls

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,14 @@
 User-agent: *
 Disallow: /ansible-core/
+
+User-agent: *
+Disallow: /ansible-container/
+
+User-agent: *
+Disallow: /archive/
+
+User-agent: *
+Disallow: /v1/
+
 Sitemap: https://docs.ansible.com/ansible-sitemap.xml
 Sitemap: https://docs.ansible.com/automation-controller-sitemap.xml


### PR DESCRIPTION
This PR updates the robots.txt file to disallow crawlers on URLs for old projects and for pages that no longer exist.