### PR TITLE
make pip compile req file path relative to project

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import nox
@@ -28,8 +29,8 @@ def pip_compile(session: nox.Session, req: str):
     )
     injected_extra_cli_args = () if has_upgrade_related_cli_flags else ("--upgrade",)
 
-    output_file = Path(f"requirements/{req}.txt")
-    input_file = Path(f"requirements/{req}.in")
+    output_file = os.path.relpath(Path(requirements_directory / f"{req}.txt"))
+    input_file = os.path.relpath(Path(requirements_directory / f"{req}.in"))
 
     session.run(
         "pip-compile",

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,9 +1,8 @@
-import os
 from pathlib import Path
 
 import nox
 
-requirements_directory = Path("requirements").resolve()
+requirements_directory = Path("requirements")
 
 requirements_files = [
     requirements_input_file_path.stem
@@ -29,16 +28,13 @@ def pip_compile(session: nox.Session, req: str):
     )
     injected_extra_cli_args = () if has_upgrade_related_cli_flags else ("--upgrade",)
 
-    output_file = os.path.relpath(Path(requirements_directory / f"{req}.txt"))
-    input_file = os.path.relpath(Path(requirements_directory / f"{req}.in"))
-
     session.run(
         "pip-compile",
         "--output-file",
-        str(output_file),
+        str(requirements_directory / f"{req}.txt"),
         *session.posargs,
         *injected_extra_cli_args,
-        str(input_file),
+        str(requirements_directory / f"{req}.in"),
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,13 +28,16 @@ def pip_compile(session: nox.Session, req: str):
     )
     injected_extra_cli_args = () if has_upgrade_related_cli_flags else ("--upgrade",)
 
+    output_file = Path(f"requirements/{req}.txt")
+    input_file = Path(f"requirements/{req}.in")
+
     session.run(
         "pip-compile",
         "--output-file",
-        str(requirements_directory / f"{req}.txt"),
+        str(output_file),
         *session.posargs,
         *injected_extra_cli_args,
-        str(requirements_directory / f"{req}.in"),
+        str(input_file),
     )
 
 


### PR DESCRIPTION
This change results in the paths of the output and input files relative to the project directory when pip-compiling requirements.