### PR TITLE
rm community ee redirects

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -367,10 +367,3 @@ RedirectMatch permanent "^\/ansible-tower\/((2\.\d\.\d)|3\.[0-3]\.\d)\/html(_\w+
 
 RedirectMatch permanent "^/ansible-lint/*" "https://ansible-lint.readthedocs.io"
 
-# Redirect getting started with execution environments to ecosystem docsite
-
-RedirectMatch permanent "^/ansible/(devel|latest)/getting_started_ee/introduction.html" "https://ansible.readthedocs.io/en/latest/getting_started_ee/introduction.html"
-RedirectMatch permanent "^/ansible/(devel|latest)/getting_started_ee/setup_environment.html" "https://ansible.readthedocs.io/en/latest/getting_started_ee/setup_environment.html"
-RedirectMatch permanent "^/ansible/(devel|latest)/getting_started_ee/build_execution_environment.html" "https://ansible.readthedocs.io/en/latest/getting_started_ee/build_execution_environment.html"
-RedirectMatch permanent "^/ansible/(devel|latest)/getting_started_ee/run_execution_environment.html" "https://ansible.readthedocs.io/en/latest/getting_started_ee/run_execution_environment.html"
-RedirectMatch permanent "^/ansible/(devel|latest)/getting_started_ee/run_community_ee_image.html" "https://ansible.readthedocs.io/en/latest/getting_started_ee/run_community_ee_image.html"


### PR DESCRIPTION
This change removes the redirects for the community ee content. Should be merged after this PR is integrated and docs are back -> https://github.com/ansible/ansible-documentation/pull/1852