### PR TITLE
Restore hamburger menus

### DIFF
--- a/templates/_scripts.html
+++ b/templates/_scripts.html
@@ -1,4 +1,4 @@
 <script src="{{ base.base_url }}static/js/iframeResizer.min.js" type="javascript"></script>
 <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" crossorigin="anonymous"></script>
-<script src="https://www.ansible.com/hubfs/js/scripts.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://www.redhat.com/dtm.js"></script>


### PR DESCRIPTION
Fixes #263 

This change replaces `scripts.min.js` that was previously available from HubSpot with the Bootstrap alternative. 

Apparently we missed the `.js` stuff when we added the minified css: https://github.com/ansible/docsite/commit/3f98e6642c1ce27464f17ca1306414442cd904d2