### PR TITLE
update reqs dir in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     labels:
       - "actions"
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "requirements/"
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
Looking at the logs from this dependabot run: https://github.com/ansible/docsite/actions/runs/14000128009/job/39204494666

It seems dependabot is having trouble finding the requirements:

```
updater | 2025/03/21 20:14:56 WARN <job_984669263> Please check your configuration as there are groups where no dependencies match:
- pip

This can happen if:
- the group's 'pattern' rules are misspelled
- your configuration's 'allow' rules do not permit any of the dependencies that match the group
- the dependencies that match the group rules have been removed from your project
```

And then further down...

```
updater | 2025/03/21 20:14:56 WARN <job_984669263> Skipping update group for 'pip' as it does not match any allowed dependencies.
updater | 2025/03/21 20:14:56 INFO <job_984669263> Found no dependencies to update after filtering allowed updates in /requirements
```

Maybe it is looking in `/requirements` when it should be just `requirements/`.