### PR TITLE
Add 4.5 to the list of archived controller doc versions

### DIFF
--- a/data/controller_archive.yaml
+++ b/data/controller_archive.yaml
@@ -1,4 +1,7 @@
 # Archive pages for Controller
+v_4_5:
+  link: "https://docs.ansible.com/automation-controller/4.5/html/"
+  button: Automation Controller version 4.5 (Supported)
 v_4_4:
   link: "https://docs.ansible.com/automation-controller/4.4/html/"
   button: Automation Controller version 4.4 (Supported)


### PR DESCRIPTION
This will allow the https://docs.ansible.com/automation-tower-prior-versions.html page to show updated list of older versions.