### PR TITLE
bump setuptools

### DIFF
--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -22,5 +22,5 @@ wheel==0.43.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0
     # via pip-tools
-setuptools==70.0.0
+setuptools==80.9.0
     # via pip-tools


### PR DESCRIPTION
The changes in https://github.com/ansible/docsite/pull/276/files don't look quite right. I used `nox -s "pip-compile-3.11(pip-tools)" -- --upgrade-package=setuptools` instead.