### PR TITLE
create the index-archive page

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -8,7 +8,7 @@ RewriteEngine On
 # except for page names listed in parentheses
 #####################################################################
 
-RedirectMatch permanent "^/((?!index|404|automation.*|ansible_community|collections|community|core.*|galaxy|lint|ecosystem|users|developers|maintainers|platform|ansible-prior*)[^/]+)\.html" "/ansible/$1.html"
+RedirectMatch permanent "^/((?!index|index-archive|404|automation.*|ansible_community|collections|community|core.*|galaxy|lint|ecosystem|users|developers|maintainers|platform|ansible-prior*)[^/]+)\.html" "/ansible/$1.html"
 
 #####################################################################
 # This section replaces rules defined for older versions that

--- a/index-archive.html
+++ b/index-archive.html
@@ -1,0 +1,69 @@
+
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Red Hat Ansible Automation Platform | Ansible Documentation</title>
+    <meta name="description" content="Ansible Documentation" />
+    <meta name="author" content="Ansible Community" />
+    <link rel="canonical" href="https://docs.ansible.com/platform.html"/>
+    <link rel="stylesheet"
+      href="https://static.redhat.com/libs/redhat/redhat-font/2.0.0/webfonts/red-hat-font.css"/>
+    <link rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.1.0/css/all.css"
+      integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt"
+      crossorigin="anonymous"/>
+    <link rel="stylesheet" href="https://docs.ansible.com/static/css/styles.min.css"/>
+    <link rel="stylesheet" href="https://docs.ansible.com/static/css/main.css">
+    <link rel="stylesheet" href="https://docs.ansible.com/static/css/redhat-footer.css">
+  </head>
+  <body>
+<div class="container">
+    <div class="full-width-bg component">
+      <div class="grid-wrapper">
+        <div class="width-12-12 width-12-12-m">
+          <div class="page-title">
+            <h2>Red Hat Ansible Automation Controller documentation</h2>
+            <p>Welcome to Ansible Automation Controller documentation.</p>
+          </div>
+        </div>
+        <div class="width-12-12 width-12-12-m">
+          <h3>Notice on domain name changes</h3>
+          <p>We're moving the <i>docs.ansible.com</i> subdomain to Read The Docs hosting. At the end of the migration effort, you will be able to find documentation for all Ansible community ecosystem projects under the <i>docs.ansible.com</i> subdomain. However the legacy documentation for Ansible Automation Controller will no longer be available from <i>docs.ansible.com</i>. We will use redirects to avoid broken links but Ansible Automation Controller documentation will be hosted from the <i>legacy-controller-docs.ansible.com</i> subdomain only. You can read more about the migration in <a href="https://forum.ansible.com/t/we-re-moving-to-read-the-docs/43519" target="_blank">forum post.</a></p>
+        </div>
+        <!-- Start platform docs. -->
+        <div class="width-6-12 width-12-12-m">
+          <h3>Red Hat Ansible Automation Platform</h3>
+          <p>Red Hat Ansible Automation Platform provides everything needed to create, execute, and manage automation in a single subscription. From execution environments to certified collections to automation analytics, discover the features and benefits of Ansible Automation Platform. This now includes Ansible controller 4.5 documentation, except the CLI and Release notes listed below.</p>
+          <a class="btn" href="https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform" role="button">Visit the Red Hat Ansible Automation Platform documentation</a>
+        </div>
+        <div class="width-6-12 width-12-12-m">
+          <h3>Automation Controller documentation</h3>
+          <p>Find documentation for Ansible Automation Controller.</p>
+          <a class="btn" href="platform.html" role="button">Visit the Ansible Automation Controller documentation archive</a>
+        </div>
+        <!-- End platform docs. -->
+      </div>
+    </div>
+  </div>
+
+    <div class="content-slim redhat-footer">
+  <span class="licence">
+    <i class="fab fa-creative-commons"></i><i class="fab fa-creative-commons-by"></i> <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">CC BY-SA 4.0 |</a>
+    <a href="https://www.redhat.com/en/about/privacy-policy">Privacy policy |</a>
+  </span>
+  <span class="redhat">
+    Sponsored by
+  </span>
+  <span class="redhat-logo">
+    <a href="https://www.redhat.com/" target="_blank"><img src="https://docs.ansible.com/static/images/redhat_reversed.svg" alt="Red Hat logo"></a>
+  </span>
+</div>
+    <script src="https://docs.ansible.com/static/js/iframeResizer.min.js" type="javascript"></script>
+<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://www.redhat.com/dtm.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
The index-archive page is required to set up the web server for the legacy-controller-docs subdomain.
See https://forum.ansible.com/t/we-re-moving-to-read-the-docs/43519/2#p-132529-creating-a-separate-landing-page-5